### PR TITLE
feat: declarative requirements + docs + CI (clean history)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions: read-all
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-test:
+    name: Lint and Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install dev dependencies
+        run: uv venv && uv pip install -e ".[dev]"
+
+
+
+      - name: Ruff (lint)
+        run: uv run ruff check .
+
+      - name: Pytest
+        run: uv run pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,4 @@ marimo/_lsp/
 __marimo__/
 
 .idea/
+ideas/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,216 @@
+# Engineering Protocol for Python Agent Development
+
+### A Guide for AI and Human Contributors
+
+## 1. Mission Briefing
+
+This document outlines the engineering principles and development protocols applicable to this project and to modern Python development in general. As a contributor to this codebase, whether AI or human, you **are required to** adhere to these standards.
+
+Our primary objective is not merely to write code that runs, but to build a system that is robust, maintainable, performant, and reliable. Your success as a contributor will be measured by your disciplined adherence to these protocols.
+
+## 2. Core Principles
+
+1.  **Elegant design**: Strive for simplicity and elegance in your solutions. Avoid over-engineering; the simplest solution that meets the requirements is often the best. Follow established design patterns and best practices.
+2.  **Clarity of code**: Write code that is easily understood by the next contributor.Avoid obscure language features or overly complex one-liners. The Zen of Python (`import this`) is our guiding philosophy. Code is read far more often than it is written.
+2.  **Type Safety and Explicitness**: All new code **shall** be fully type-hinted. Static type checking is not optional; it is a fundamental tool for preventing entire classes of bugs and improving code comprehensibility.
+3.  **Test Rigorously**: A feature without tests is an incomplete feature. Untested code is considered legacy or broken by default. Tests are a form of living documentation and a safety net for future changes.
+4.  **Automate Everything**: All formatting, linting, type checking, testing, and deployment processes **shall** be automated through a CI/CD pipeline. Human intervention in these processes should be the exception, not the rule.
+5.  **Document Diligently**: While code should be as self-documenting as possible, this does not replace formal documentation. Your changes **must** be accompanied by clear explanations, docstrings, and updates to project-level documentation where necessary.
+6.  **Design Before Code**: Significant new features or architectural changes require a concise Architecture Decision Record (ADR). This practice forces clear thinking upfront and serves as a historical record of the project's evolution.
+7.  **Principle of Focused, Atomic Changes**: Avoid large, monolithic refactors. Changes should be small, focused, and submitted as atomic commits within a single Pull Request. Each PR should do one thing and do it well.
+
+## 3. Technical Protocols
+
+### 3.1. Code Quality & Style
+
+* **Formatting**: All Python code **must** be formatted using `black` with its default configuration.
+* **Linting**: All Python code **must** pass `ruff` checks without any warnings. Custom rules may be defined in `pyproject.toml`.
+* **Import Sorting**: All Python imports **must** be sorted using `isort` (project defaults). Keep grouping and ordering deterministic.
+* **Type Checking**: All Python code **must** pass static analysis by `mypy` in strict mode (`--strict`).
+* **Automation**: These checks (**ruff**, **black**, **isort**, **mypy**, **pytest**) **must** be automated locally using the `pre-commit` framework. Any commit that fails pre-commit hooks will be rejected by the CI pipeline. Provide convenience scripts/Make targets where helpful.
+* **Modularity**: Functions and classes should be small and adhere to the Single Responsibility Principle (SRP).
+* **Naming**: Follow the PEP 8 naming conventions. Use descriptive, unambiguous names for variables, functions, and classes.
+
+#### 3.1.1 Mapping ergonomics (dict "destructuring")
+
+- Prefer `operator.itemgetter` or `gcmi.utils.struct.take/require` for required keys (concise, fast, explicit KeyError on missing keys).
+- For nested access, use `gcmi.utils.struct.take_nested` with dotted paths in validators, config assembly, and middleware wiring.
+- Structural pattern matching (`match`/`case`, Python 3.10+) is allowed where it clearly improves readability or you need to bind the “rest” via `**rest`. Avoid in tight loops/hot paths.
+- Avoid ad‑hoc "dotdict" wrappers; they degrade static checking and may hide missing keys. Use `TypedDict`/`NamedTuple` views if helpful, while keeping runtime objects as plain dicts.
+- Do not introduce silent defaults at call sites. Defaults belong in the validated config schema.
+
+Examples:
+
+```python
+from operator import itemgetter as ig
+from gcmi.utils.struct import take, require, take_nested
+
+# Required flat keys (fast path)
+T, q, u, v = take(state, "T", "q", "u", "v")
+
+# Better error on missing keys
+(dx_min,) = require(params["grid"], "dx_min")
+
+# Nested access with dotted paths
+dx_min, theta = take_nested(params, "grid.dx_min", "spectral.semi_implicit.theta")
+
+# Structural pattern matching when readability matters
+match state:
+    case {"T": T, "q": q, "u": u, "v": v, **rest}:
+        ...
+```
+
+#### 3.1.2 Declarative runtime requirements (decorator + early-check middleware)
+
+Use a small, explicit contract to declare what a component needs from `state` / `params` / `forcing`, and validate only in the first few steps for minimal overhead later.
+
+- API (gcmi.utils.requirements)
+  - `Requirement(where, path, required=True, type=None, predicate=None, severity="error")`
+    - `where`: `"state" | "params" | "forcing"`
+    - `path`: dotted path, e.g. `"spectral.radius"` or `"grid.dx_min"`
+    - `type`: `isinstance` check (type or tuple of types)
+    - `predicate`: `callable(value) -> bool`, must return True
+    - `severity`: `"error"` (default) or `"warn"`
+  - `@requires(*Requirement)`: attach requirements to a StepFn or callable
+  - `get_requirements(fn)`: retrieve attached requirements (follows `__wrapped__`)
+  - `validate_requirements(...)`: validate against containers, returns `(errors, warnings)`
+- Middleware (gcmi.middleware.requirements)
+  - `with_requirements_check(step, *, max_checks=3, raise_on_error=True, record_warnings=True)`
+  - Validates attached (+extra) requirements only for the first `max_checks` invocations; then skips checks entirely.
+
+Example (SpectralOps: require params.spectral.radius > 0)
+```python
+from gcmi.utils.requirements import Requirement, requires
+from gcmi.middleware.requirements import with_requirements_check
+
+@requires(Requirement("params", "spectral.radius", type=(int, float), predicate=lambda r: r > 0.0))
+def step_core(state, forcing, params, dt, *, xp):
+    # physics/dynamics tendencies...
+    return state, {}
+
+# Enforce only in early steps (e.g., first 3); afterwards skip for performance.
+step = with_requirements_check(step_core, max_checks=3, raise_on_error=True)
+```
+
+Guidelines
+- Prefer `@requires` at definition sites of step functions/middleware that need structural inputs (e.g., spectral adapters expect `params.spectral.radius`).
+- Drivers/examples should wrap the assembled `step` with `with_requirements_check(...)` to fail fast at startup while keeping steady-state cost zero.
+- Keep predicates side-effect free and simple; use `type` and `required` where possible.
+- On violation with `raise_on_error=False`, the wrapper records a summary under `diag["gcmi_requirements"]` for audit.
+
+### 3.2. Testing Protocol (Mandatory)
+
+* **Framework**: `pytest` is the standard testing framework for this project.
+* **Unit Tests**: Must cover the happy path, edge cases, and error conditions for individual components. Mocking should be used judiciously to isolate units under test.
+* **Integration Tests**: Must verify that different parts of the application collaborate correctly. This includes API endpoints, data pipelines, and interactions with external services, using dedicated test datasets.
+* **Coverage**: While we do not enforce a strict percentage, all new code must be accompanied by tests, and Pull Requests that decrease test coverage will be scrutinized. Use `pytest-cov` to monitor coverage.
+
+### 3.3. Documentation Protocol
+
+**Guiding Principle**: Documentation is a critical component of the software, not an afterthought. It must be created and maintained with the same rigor as the code. Our documentation is categorized into three primary types:
+
+1.  **User-Facing Documentation**
+    * **Purpose**: To enable end-users to effectively understand, install, and use the software/service.
+    * **Components**:
+        * `README.md`: Must contain a clear project overview, installation steps, and quick-start examples.
+        * `CHANGELOG.md`: Must be kept current following the "Keep a Changelog" format, detailing all user-visible changes for each release.
+        * **User Guides & Tutorials**: For complex features, dedicated guides or tutorials should be created (e.g., in a `/docs` directory).
+        * **API Reference**: For any public APIs, a clear, complete, and preferably auto-generated reference (e.g., via Sphinx/MkDocs from docstrings) is mandatory.
+
+2.  **Developer-Facing Documentation**
+    * **Purpose**: To enable current and future developers to efficiently understand, maintain, and contribute to the codebase.
+    * **Components**:
+        * **Docstrings**: All public modules, functions, classes, and methods **must** have docstrings compliant with PEP 257 (Google or NumPy style recommended). These serve as the source for auto-generated internal API documentation.
+        * `CONTRIBUTING.md`: A dedicated file explaining how to set up the development environment, run tests, adhere to style guides, and submit a pull request.
+        * **Architectural Documentation**: Includes diagrams, Architecture Decision Records (ADRs), and explanations of core components and internal workflows.
+
+3.  **Project/Feature Design Documentation**
+    * **Purpose**: To define the scope, technical design, implementation plan, and risks for new features or significant changes *before* implementation begins. This directly aligns with our "Design Before Code" core principle.
+    * **Workflow**:
+        1.  **Proposal**: A design document (such as an ADR or a technical specification) **must** be created and reviewed before development.
+        2.  **Status Tracking**: The document's status (e.g., `Draft`, `In Review`, `Approved`, `Implemented`, `Deprecated`) **must** be clearly marked and kept up-to-date with the project's progress.
+        3.  **Post-Implementation Integration**: Upon completion of the feature, relevant information from the design (e.g., new API endpoints, architectural changes) **must** be integrated into the user-facing and developer-facing documentation. This ensures the internal consistency of the entire documentation system. The design document is then archived as a historical record.
+
+### 3.4. Version Control (Git) Protocol
+
+* **Authorization**: You are authorized to use `git` and the GitHub CLI (`gh`) for all repository interactions.
+* **Branching**: All work **must** be done on feature branches created from the `main` branch. Direct commits to `main` are prohibited. Branch names should be descriptive (e.g., `feat/add-user-authentication`, `fix/resolve-caching-bug`).
+* **Commit Messages**: Commits **must** follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. This is essential for automated versioning and changelog generation.
+* **Pull Requests (PRs)**: Your PR description **must** clearly explain the "what" (what was done) and the "why" (the business or technical reason for the change). Link to relevant issues or ADRs.
+
+### 3.5. Error Handling Protocol
+
+* **No Silent Failures**: Functions **must not** silently ignore errors (e.g., via a bare `except:` block). Fail loudly and explicitly.
+* **Custom Exceptions**: A well-defined hierarchy of custom exceptions is encouraged to provide specific, actionable error information to callers.
+* **Clarity**: Error messages should be clear, concise, and provide context to help with debugging.
+
+### 3.6. Performance Protocol
+
+* **Benchmarking**: Use `pytest-benchmark` for performance-critical functions to quantify the impact of changes.
+* **No Premature Optimization**: "Premature optimization is the root of all evil." First, make it work. Then, make it right. Only then, if necessary, make it fast. Performance improvements **must** be driven by profiling and identifying actual bottlenecks.
+
+## 4. Operational Protocols
+
+### 4.1. Dependency & Environment Management
+
+* **Dependency Manager**: `uv` is the standard tool for managing dependencies and virtual environments.
+* **Environment Isolation**: All development **must** occur within a virtual environment to prevent dependency conflicts.
+* **Dependency Declaration**: All project dependencies **must** be explicitly declared in the `[project.dependencies]` section of `pyproject.toml`. Lock files generated by `uv` ensure reproducible builds.
+* **Python Version**: The project's required Python version **shall** be pinned (e.g., via a `.python-version` file for `pyenv`) to ensure consistency across all development and production environments.
+
+### 4.2. Logging Protocol
+
+* **Library**: Use the standard `logging` library.
+* **Structured Logging**: Logs should be structured (e.g., JSON format) in production environments to facilitate parsing and analysis by monitoring tools.
+* **Levels**: Use appropriate log levels (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). Avoid excessive logging, especially at the `INFO` level.
+* **Content**: Log messages should include a timestamp, log level, module name, and a descriptive message. Avoid logging sensitive information.
+
+### 4.3. Configuration Management
+
+* **Source**: Configuration should be loaded from environment variables or dedicated configuration files (`.toml`, `.yaml`), never hardcoded.
+* **Validation**: Use a library like `pydantic` to define, validate, and manage application configuration. This provides type safety and clear error messages for invalid configurations.
+* **Secrets Management**: Sensitive information (API keys, passwords) **must never** be committed to the repository. Use a secrets management system (e.g., HashiCorp Vault, AWS Secrets Manager) or environment variables.
+
+### 4.4. Security Protocol
+
+* **Dependency Scanning**: Regularly scan dependencies for known vulnerabilities using tools like `safety` or `pip-audit`. This **shall** be part of the CI pipeline.
+* **Static Analysis**: Employ Static Application Security Testing (SAST) tools to identify potential security flaws in the codebase.
+* **Principle of Least Privilege**: The application should run with the minimum permissions necessary to perform its function.
+
+### 4.5. Code Review Protocol
+
+* **Mandatory Review**: All PRs **must** be reviewed and approved by at least one other developer before being merged.
+* **Review Focus**: Reviews should be constructive and focus on code quality, correctness, test coverage, documentation, and adherence to these protocols.
+* **Author's Responsibility**: The PR author is responsible for ensuring their code is clean, tested, and easy to review. They are also expected to respond to feedback in a timely manner.
+* **Reviewer's Responsibility**: The reviewer is responsible for providing thorough, respectful, and actionable feedback. The goal is collaborative improvement of the codebase, not personal criticism.
+
+## 5. Engineering Checklist (Pre-merge)
+
+Before merging any change, complete the following:
+
+- Code Quality & Tests
+  - [ ] Run ruff with autofix: `ruff check . --fix`
+  - [ ] Run black formatting: `black .`
+  - [ ] Run import sorting: `isort .`
+  - [ ] Run tests: `pytest -q` (and ensure non-flaky, meaningful coverage)
+  - [ ] (If applicable) Run mypy: `mypy --strict .` and resolve typing issues
+  - [ ] Ensure pre-commit hooks are installed and passing locally
+
+- Documentation Updates
+  - [ ] Update README.md if user-facing behavior or commands changed
+  - [ ] Update /docs (user + technical) where relevant:
+        - User docs (e.g., data handling, training, inference, evaluation)
+        - Technical docs (e.g., extension guides, specifications)
+  - [ ] Update docs/index.md navigation to include any new docs pages
+  - [ ] Add code docstrings for new/changed public APIs
+
+- Project Hygiene
+  - [ ] Update CHANGELOG.md with user-visible changes (Keep a Changelog format)
+  - [ ] If introducing new conventions or tools, update AGENTS.md accordingly
+  - [ ] Verify CI configuration enforces ruff, black, isort, mypy, pytest
+  - [ ] Consider version bump if public API/CLI changes
+
+- PR Quality
+  - [ ] Reference related ADRs/Project docs (e.g., Projects/00x_*.md)
+  - [ ] Provide a clear PR description covering the "what" and "why"
+  - [ ] Keep changes focused and atomic; avoid unrelated refactors

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # py-gcmi
+
 The Python reference implementation of GCMI, with core APIs, middleware, hooks, and examples.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,301 @@
+# System Design — py-gcmi
+
+Status: Draft
+Aligns with: GCMI Core 0.1 (proposed); SpectralOps 0.1 (experimental)
+Last Updated: 2025-09-22
+
+1. Architectural Overview
+
+- Philosophy: WSGI-style minimal core plus composable middleware that modify state, and read-only hooks for observability. Favor pure functions and explicit data flow. No implicit globals. Backend neutrality via xp and ops facades (NumPy/JAX/Torch).
+- Layers
+  - Core: init_fn/step_fn/run_fn – minimal, typed, backend-neutral.
+  - Middleware: numerical stabilization, limiting, conservation, methods.
+  - Hooks: logging/diagnostics/IO; strictly observational.
+  - Ops: grid operators and optional spectral operators.
+  - Drivers: default sequential runner; space for parallel variants later.
+  - Config: env → cfg → params bridge with validation.
+
+2. Core API (GCMI Core 0.1)
+
+```python
+from typing import Protocol, Mapping, Any, Tuple, Callable, Dict
+
+class ArrayLike(Protocol): ...
+class XP(Protocol): ...  # numpy, jax.numpy, torch-like
+
+State  = Dict[str, ArrayLike]
+Forcing = Dict[str, ArrayLike]
+Params = Mapping[str, Any]
+Diag   = Dict[str, Any]
+
+StepFn = Callable[[State, Forcing, Params, float], Tuple[State, Diag]]
+
+def init_fn(cfg: Mapping[str, Any], *, xp: XP) -> Tuple[State, Params]: ...
+def step_fn(state: State, forcing: Forcing, params: Params, dt: float, *, xp: XP) -> Tuple[State, Diag]: ...
+def run_fn(init: State, params: Params, forcing_stream, *,
+           xp: XP, n_steps: int,
+           hooks: Tuple[Callable[[int, State, Diag], None], ...] = ()
+          ) -> Tuple[State, Mapping[str, Any]]: ...
+```
+
+- Semantics
+  - State/Forcing/Params specify keys and meanings, not concrete tensor types.
+  - No hidden global state; reproducibility via Params and State["misc"]["rng"].
+  - Versioning: diag["gcmi_version"] and per-middleware metadata for audit.
+
+3. Data Model: Initial Keys and Semantics
+
+- State: {"T", "q", "u", "v", "misc", optional "spec": {"zeta_lm","div_lm", ...}}
+- Forcing: {"SW","LW","topo", ...} according to examples.
+- Params:
+  - "grid": {"dx_min", "metric", "mask", ...}
+  - "ops": references to backend implementations (grid/spectral)
+  - "energy_budget": {"target_total", ...}
+  - "backend": {"xp": xp module or compatible namespace}
+- Diag: {"gcmi_mw": [ ... ], "timings": ..., other per-step diagnostics}
+
+4. Middleware Contract
+
+- Definition: mw: (StepFn) -> StepFn, pure and composable, no global state.
+- Responsibilities: stabilization (CFL/substeps), limiters, positivity, conservation projection, semi-implicit methods, nudging, substepping, RNG normalization.
+- Ordering guidelines:
+  - Outer: stability wrappers (CFL/substeps).
+  - Middle: local fixups (limiters, hyperdiff, positivity).
+  - Tail: global consistency (energy fix, conservation projection).
+  - Boundary: sponge/radiation handling.
+- Each middleware appends metadata into diag["gcmi_mw"].
+
+5. Hook Contract
+
+- Signature: hook(k: int, state: State, diag: Diag, *, params, xp, ...) -> None.
+- Strictly observational: logging, budget tables, IO, timing.
+- Must not modify State or Params.
+
+6. Ops Facade (Grid)
+
+- Encapsulates differential operators, stencils, basic filters, and metric handling.
+- Backend-neutral call sites; configurable via Params["ops"] and xp.
+
+7. SpectralOps Extension (Experimental)
+
+```python
+class SpectralOps(Protocol):
+    def sh_forward(self, grid_scalar) -> "spec_array": ...
+    def sh_inverse(self, spec_array) -> "grid_scalar": ...
+    def uv_from_vort_div(self, zeta_lm, div_lm): ...
+    def vort_div_from_uv(self, u, v): ...
+    def laplacian_eig(self, l: int) -> float: ...  # -l(l+1)/a^2
+    def spectral_filter(self, spec_array, kind="hypervisc", power=4, coef=...): ...
+    def dealias(self, spec_array, rule="two_thirds"): ...
+    def helmholtz_solve(self, spec_rhs, alpha): ...
+```
+
+- State may lazily maintain both grid and spectral forms. Physical processes remain on grid; dynamics via pseudo-spectral middleware.
+- Implementation examples: NumPy+shtns, JAX+jax-sht, Torch+custom kernels. Optional and capability-negotiated.
+
+8. Spectral Dynamics Middleware (Pseudo-spectral path)
+
+- with_spectral_dyn_core(step_core, theta=0.5, hypervisc=(4, 1e-4)):
+  - spec→grid (recover u,v), compute nonlinear terms on grid, grid→spec, advance (explicit or θ semi-implicit via Helmholtz), spectral hyperviscosity + dealiasing, write back and delegate to step_core, log metadata.
+- Physics interplay: physics tendencies on grid; synchronization managed lazily; conservation checks handled by generic middleware.
+
+9. Configuration and Schemas
+
+- load_cfg() produces validated cfg. Env variables are inputs but normalized into cfg; downstream code does not read env directly.
+- Typical cfg keys:
+  - backend.xp, nsteps, grid (dx, dy, mask), spectral (truncation, radius, dealiasing), middleware parameters (coefficients, limits), IO/hook intervals.
+
+10. Error Handling, Logging, Observability
+
+- No silent failures; explicit exceptions for invalid inputs/configurations.
+- logging with structured output in production contexts (JSON).
+- Hooks produce CSV/NDJSON for budgets/timings; diag carries per-step metadata.
+
+11. Testing Strategy
+
+- pytest with strict typing and style checks (mypy --strict, ruff, black, isort).
+- Baseline tests:
+  - Conservation baseline (dry, no forcing): mass/energy/water within epsilon over N steps.
+  - Stability baseline under varied dt/resolution: no blow-up; CFL guard effective.
+  - Reproducibility baseline (fixed RNG): within tolerances across supported backends where applicable.
+  - Spectral roundtrip and Helmholtz tests (if SpectralOps is enabled).
+- Coverage monitored via pytest-cov.
+
+12. Performance Considerations
+
+- Minimize Python-level loops; vectorize via xp.
+- Batch operations in ops; profile with timing hooks.
+- Spectral transforms are global reductions; keep optional and well-factored; provide knobs (power, coef, dealias rule).
+
+13. CI/CD and Tooling
+
+- Pre-commit: ruff, black, isort, mypy --strict, pytest.
+- GitHub Actions: enforce AGENTS.md checklist on PRs and main.
+- CHANGELOG maintained with Keep a Changelog format.
+
+14. API Stability and Versioning
+
+- py-gcmi __version__ declares supported GCMI Core/SpectralOps versions.
+- Backward-compatible additions favored; breaking changes require ADR + semver bump.
+
+15. Example Assembly (Sketch)
+
+```python
+from gcmi.core.api import init_fn, run_fn, step_fn
+from gcmi.middleware import (
+    with_cfl_guard, with_hyperdiff, with_flux_limiter,
+    with_positivity, with_energy_fix, with_conservation_projection
+)
+from gcmi.hooks import energy_budget_hook
+
+xp = numpy  # or jax.numpy / torch
+state0, params = init_fn(cfg, xp=xp)
+
+step = step_fn  # core tendencies only
+step = with_flux_limiter(step, scheme="mc", vars=("q","T"))
+step = with_hyperdiff(step, coeff=2e-3, order=4, vars=("T","u","v"))
+step = with_positivity(step, vars=("q",), lower=0.0, conserve="total_q")
+step = with_energy_fix(step, budget=("dry_static","latent","kinetic"))
+step = with_conservation_projection(step, conserve=("total_mass","moist_energy"))
+step = with_cfl_guard(step, cfl_max=0.8, wave_speed_cb=wave_speed_cb)
+
+final_state, report = run_fn(
+    state0, params, forcing_stream,
+    xp=xp, nsteps=cfg["nsteps"],
+    hooks=(lambda k, st, dg: energy_budget_hook(k, st, dg, params=params, xp=xp),)
+)
+```
+
+16. Ergonomic Dict Handling (Pythonic “destructuring”)
+
+Goal: keep mapping-based APIs (State/Params/Forcing) while writing concise, readable, and type-checkable access patterns.
+
+Core idioms
+- operator.itemgetter for tuple-unpack (fast, concise):
+  ```python
+  from operator import itemgetter as ig
+  T, q, u, v = ig("T", "q", "u", "v")(state)
+  ```
+- Structural pattern matching (Python 3.10+) for readability and capturing “rest”:
+  ```python
+  match state:
+      case {"T": T, "q": q, "u": u, "v": v, **rest}:
+          ...
+  match params:
+      case {"grid": {"dx_min": dx_min, **_}, **_}:
+          ...
+  ```
+- NamedTuple “views” for frequent bundles (adds attribute names):
+  ```python
+  from typing import NamedTuple, Any
+  class UV(NamedTuple):
+      u: Any; v: Any
+  def uv_view(d: dict) -> UV:
+      from operator import itemgetter as ig
+      return UV(*ig("u","v")(d))
+  u, v = uv_view(state)
+  ```
+
+Lightweight utilities (to be placed under gcmi/utils/struct.py)
+- take: minimal, fast destructuring for required keys (thin wrapper on itemgetter)
+  ```python
+  from operator import itemgetter
+  from typing import Mapping, Any, Tuple
+  def take(d: Mapping[str, Any], *keys: str) -> Tuple[Any, ...]:
+      return itemgetter(*keys)(d)
+  ```
+- require: take but with clearer KeyError message
+  ```python
+  def require(d: Mapping[str, Any], *keys: str) -> Tuple[Any, ...]:
+      try:
+          return itemgetter(*keys)(d)
+      except KeyError as e:
+          miss = e.args[0]
+          raise KeyError(f"Missing required key '{miss}'. Expected {keys}. Available {list(d.keys())}") from e
+  ```
+- take_nested: dotted-path access for nested dicts (cfg/params)
+  ```python
+  from typing import Any, Mapping, Tuple
+  def take_nested(d: Mapping[str, Any], *paths: str) -> Tuple[Any, ...]:
+      def get_path(obj: Any, path: str) -> Any:
+          cur = obj
+          for seg in path.split("."):
+              cur = cur[seg]
+          return cur
+      return tuple(get_path(d, p) for p in paths)
+  # Example: dx_min, theta = take_nested(params, "grid.dx_min", "spectral.semi_implicit.theta")
+  ```
+- split_keys: pick keys and return (picked, rest)
+  ```python
+  from typing import Mapping
+  def split_keys(d: Mapping[str, Any], *keys: str) -> tuple[dict, dict]:
+      picked = {k: d[k] for k in keys}
+      rest = {k: v for k, v in d.items() if k not in picked}
+      return picked, rest
+  ```
+
+Style guidance
+- Prefer take/require in hot paths for brevity and speed; match-case when clarity is more important (especially when capturing the remainder).
+- Use take_nested in config validation/middleware assembly instead of multi-index chains for readability.
+- Avoid ad-hoc dotdict wrappers; they hinder static checking and can mask KeyError bugs.
+- TypedDicts are acceptable for developer ergonomics when stabilizing commonly used views (e.g., StateTD subset), while keeping runtime objects as plain dicts.
+
+16.5 Declarative Requirements (decorator + early-check middleware)
+
+Motivation
+- Components (core, middleware, spectral adapters) often need certain keys/semantics in state/params/forcing (e.g., params.spectral.radius).
+- Make these needs explicit, discoverable, and machine-checkable without cluttering the numerical code.
+
+Mechanism
+- Declarative requirement spec + decorator (gcmi.utils.requirements):
+  - Requirement(where: "state"|"params"|"forcing", path: "a.b.c", required=True, type=..., predicate=..., severity="error"|"warn")
+  - @requires(...): attach one or more Requirement to a StepFn or any callable
+  - get_requirements(fn): retrieve attached requirements (follows __wrapped__ chain)
+  - validate_requirements(...): check containers and return (errors, warnings)
+- Early-check middleware (gcmi.middleware.requirements):
+  - with_requirements_check(step, max_checks=3, raise_on_error=True, record_warnings=True)
+  - Validates attached (+extra) requirements only for the first max_checks calls, then skips for performance.
+
+Example
+```python
+from gcmi.utils.requirements import Requirement, requires
+from gcmi.middleware.requirements import with_requirements_check
+
+@requires(
+    Requirement("params", "spectral.radius", type=(int, float), predicate=lambda r: r > 0.0),
+    Requirement("state", "misc.seed", type=int, severity="warn"),  # optional warning example
+)
+def step_core(state, forcing, params, dt, *, xp):
+    # physics/dynamics tendencies here...
+    return state, {}
+
+# Enforce only in early steps (e.g., first 3); then skip
+step = with_requirements_check(step_core, max_checks=3, raise_on_error=True)
+```
+
+Behavior and auditing
+- On violation during early steps:
+  - If raise_on_error=True: raises RequirementError (fail fast).
+  - Else: attaches a summary to diag["gcmi_requirements"] for auditing.
+- After max_checks invocations, all checks are skipped to remove overhead.
+- Requirements are composable across wrappers via __wrapped__ metadata.
+
+Recommended usage
+- Middleware and drivers that have structural expectations (e.g., spectral ops) should declare them via @requires.
+- Wrap the assembled step with with_requirements_check in examples/drivers to enforce correctness in the first few steps of a run.
+- Keep predicates simple and side-effect free; use type and required flags where possible.
+
+17. Open Questions and ADRs
+
+- ADR-000: RNG normalization strategy across backends (algorithm, seeding, reproducibility).
+- ADR-001: Default middleware chain ordering and coefficients; recommended presets.
+- ADR-002: Spectral normalization conventions and truncation defaults.
+- ADR-003: Config schema and validation library choices (pydantic vs. minimal schema).
+- ADR-004: Dict ergonomics helpers standardization and their scope of use.
+
+18. Glossary
+
+- GCMI: Gateway Climate Modeling Interface (Core API).
+- Middleware: Functions that transform StepFn and modify numerical outcomes.
+- Hooks: Observers that never modify State.
+- SpectralOps: Optional facade for spherical harmonic operations.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,130 @@
+# Project Plan — py-gcmi
+
+Status: Draft
+Version: 0.1
+Last Updated: 2025-09-22
+
+Scope: Establish a minimal, testable, and well-documented Python reference implementation of GCMI Core 0.1 with an initial middleware/Hook ecosystem; provide an experimental SpectralOps integration path.
+
+1. Goals and Non‑Goals
+
+- Goals
+  - Implement GCMI Core 0.1: init_fn, step_fn, run_fn, fully type-hinted and backend-neutral (NumPy/JAX/Torch via xp facade).
+  - Provide a minimal but valuable middleware set (stability, limiting, positivity, conservation, energy fix).
+  - Provide hooks for observability (energy/water budgets, timing, simple IO).
+  - Define ops facade (grid ops; optional spectral ops) with clean capability negotiation.
+  - Ship unit tests, baseline tests, and CI per AGENTS.md (ruff, black, isort, mypy --strict, pytest).
+  - Provide runnable examples for quick validation.
+  - English-first documentation and ADRs for major decisions.
+
+- Non‑Goals (for v0.1)
+  - Full production readiness or large-scale distributed execution.
+  - Broad physics library beyond minimal tendencies suitable for examples.
+  - Rich visualization/plotting stack (keep minimal and optional).
+
+2. Milestones and Timeline (indicative)
+
+- M0 (Week 0): Approve plan & design docs
+- M1 (Week 2): Core 0.1 APIs + grid ops + minimal middleware + hooks + baseline tests
+- M2 (Week 4): Config schema + examples + CI (ruff, black, isort, mypy, pytest) green
+- M3 (Week 6): SpectralOps facade + spectral dynamics middleware (NumPy + shtns prototype; experimental)
+- M4 (Week 8): Docs polished; ADRs for key choices; tag py-gcmi 0.1.0
+
+3. Deliverables per Milestone
+
+- M1
+  - gcmi/core/api.py: init_fn, step_fn, run_fn; thin physics_core skeleton
+  - gcmi/ops/grid.py minimal operators (diffusion/Laplacian placeholders, metric access)
+  - Middleware: with_cfl_guard, with_hyperdiff, with_flux_limiter, with_positivity, with_energy_fix, with_conservation_projection
+  - Hooks: energy_budget, water_budget, timer (CSV/NDJSON outputs)
+  - Baseline tests: conservation (dry/no forcing), stability smoke, reproducibility (fixed RNG)
+
+- M2
+  - Config loader and schema (env → cfg bridge, strict validation)
+  - Examples: dry dynamics (grid), moist toy case
+  - CI: pre-commit hooks; GitHub Actions enforcing AGENTS.md toolchain
+  - Documentation: README quick start, basic user/developer guides
+
+- M3 (Experimental)
+  - ops/spectral facade (protocol + capability marker)
+  - with_spectral_dyn_core (pseudo-spectral path; θ-method + hyperviscosity + dealiasing)
+  - Spectral diagnostics hook (energy spectrum, enstrophy)
+  - Example: T42 channel/dry core run
+
+- M4
+  - Documentation polish: this plan, system design, CONTRIBUTING, ADRs
+  - “Supports GCMI Core 0.1” declaration; SpectralOps 0.1 marked experimental
+  - py-gcmi 0.1.0 release tag
+
+4. Acceptance Criteria
+
+- API: All public code has complete type hints; mypy --strict passes.
+- Quality: ruff, black, isort clean; pre-commit installed and green.
+- Tests: pytest baseline green; non-flaky; pytest-cov reports maintained.
+- Stability: CFL guard effective; positivity preserved for configured vars; hyperdiff/limiters work as configured.
+- Energy/water: energy_fix and conservation projection keep drift in baseline within epsilon budget; hooks produce interpretable CSV.
+- Examples: end-to-end runs complete with documented commands.
+- Spectral (experimental): forward/inverse roundtrip tolerance; Helmholtz solve validated; T42 run completes without blow-up.
+
+5. Risks and Mitigations
+
+- Numerical instability on varied grids
+  - Mitigation: conservative default chain order and coefficients; baseline tests + hooks.
+- Backend divergence (numpy/jax/torch)
+  - Mitigation: xp facade and ops indirection; limit backend-specific code to adapters.
+- Spectral dependency availability (shtns)
+  - Mitigation: optional dependency; graceful degrade to grid-only.
+- Scope creep
+  - Mitigation: ADR gate for features; milestone stickiness; small atomic PRs.
+
+6. Roles and Communication
+
+- Maintainers: code review, CI, tagging, ADR stewardship, releases.
+- Contributors: follow AGENTS.md protocols; small focused PRs with tests.
+- Rituals: lightweight weekly milestone sync; PR templates with “what/why” and links to ADRs.
+
+7. Versioning and Release
+
+- Semantic versioning for py-gcmi; explicit “Supports GCMI Core x.y” in docs.
+- v0.1.0 targets Core 0.1; SpectralOps 0.1 experimental.
+- CHANGELOG.md maintained using “Keep a Changelog”.
+
+8. Success Metrics
+
+- CI green on main; pre-commit enforced.
+- Baseline tests stable across runs and backends (within tolerances).
+- Middleware interoperability demonstrated in examples; hooks produce budgets.
+- Developer onboarding time: ≤ 30 minutes to run an example from a clean clone.
+
+9. Out of Scope (v0.1)
+
+- Distributed drivers (e.g., JAX pjit, Torch DDP, MPI) beyond structure placeholders.
+- Full-featured NetCDF/Zarr pipelines; advanced plotting.
+- Comprehensive physics packages (only minimal tendencies for examples).
+
+10. Dependencies and Tooling
+
+- Python ≥ 3.10; dependency management via uv.
+- Tooling: ruff, black, isort, mypy, pytest (+ pytest-cov), pre-commit.
+- Optional: shtns or alternative spectral libraries for experimental SpectralOps.
+
+11. Workstreams and Tracking
+
+- Core API & ops (owner: Core)
+- Middleware & hooks (owner: Numerics)
+- Config & examples (owner: DX)
+- Spectral extension (owner: Spectral)
+- CI & docs & ADRs (owner: Infra)
+- Each workstream publishes checklists in docs/notes or GitHub project boards.
+
+12. Deliverable Artifacts
+
+- Source code under gcmi/ with typed public APIs.
+- Tests under tests/ with baseline datasets/fixtures.
+- Docs under docs/: plan.md, design.md, ADRs, guides.
+- Examples under examples/ runnable via documented commands.
+
+Appendix: Status Labels
+
+- Draft → In Review → Approved → Implemented → Deprecated
+- All docs/pages should carry a visible status label to reflect maturity.

--- a/gcmi/core/api.py
+++ b/gcmi/core/api.py
@@ -1,16 +1,30 @@
-from typing import Protocol, Mapping, Any, Tuple, Callable, Dict
+from typing import Any, Callable, Dict, Mapping, Protocol, Tuple
+
 
 class ArrayLike(Protocol): ...
+
+
 class XP(Protocol): ...
+
 
 State = Dict[str, ArrayLike]
 Forcing = Dict[str, ArrayLike]
 Params = Mapping[str, Any]
-Diag   = Dict[str, Any]
+Diag = Dict[str, Any]
 
 StepFn = Callable[[State, Forcing, Params, float], Tuple[State, Diag]]
 
+
 def init_fn(cfg: Mapping[str, Any], *, xp: XP) -> Tuple[State, Params]: ...
-def step_fn(state: State, forcing: Forcing, params: Params, dt: float, *, xp: XP) -> Tuple[State, Diag]: ...
-def run_fn(init: State, params: Params, forcing_stream, *,
-           xp: XP, nsteps: int, hooks: Tuple[Callable[[int, State, Diag], None], ...] = ()) -> Tuple[State, Mapping[str, Any]]: ...
+def step_fn(
+    state: State, forcing: Forcing, params: Params, dt: float, *, xp: XP
+) -> Tuple[State, Diag]: ...
+def run_fn(
+    init: State,
+    params: Params,
+    forcing_stream,
+    *,
+    xp: XP,
+    n_steps: int,
+    hooks: Tuple[Callable[[int, State, Diag], None], ...] = (),
+) -> Tuple[State, Mapping[str, Any]]: ...

--- a/gcmi/middleware/requirements.py
+++ b/gcmi/middleware/requirements.py
@@ -1,0 +1,111 @@
+"""
+Requirements-checking middleware.
+
+Wrap a StepFn to enforce declarative requirements (attached via
+gcmi.utils.requirements.requires or provided explicitly) during the first
+N invocations, then skip checks for performance.
+
+This follows the design goal:
+- Make component needs explicit and declarative.
+- Fail fast (or warn) in early steps; avoid overhead later.
+
+Example
+-------
+from gcmi.utils.requirements import Requirement, requires
+from gcmi.middleware.requirements import with_requirements_check
+
+@requires(Requirement("params", "spectral.radius", type=(int, float), predicate=lambda r: r > 0))
+def step_fn(state, forcing, params, dt, *, xp):
+    ...
+
+step = with_requirements_check(step_fn, max_checks=3)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Mapping, Sequence, Tuple
+
+from gcmi.utils.requirements import (
+    Requirement,
+    RequirementError,
+    get_requirements,
+    validate_requirements,
+)
+
+# Loose typing to avoid import-cycle with core types
+StepFn = Callable[
+    [Mapping[str, Any], Mapping[str, Any], Mapping[str, Any], float],
+    Tuple[Mapping[str, Any], Dict[str, Any]],
+]
+
+
+def with_requirements_check(
+    step: StepFn,
+    *,
+    extra: Sequence[Requirement] = (),
+    max_checks: int = 3,
+    raise_on_error: bool = True,
+    record_warnings: bool = True,
+) -> StepFn:
+    """
+    Wrap a StepFn to validate attached (and extra) requirements for the first `max_checks` calls.
+
+    Args:
+        step: The inner step function.
+        extra: Additional requirements to enforce (in addition to those attached via decorator).
+        max_checks: Number of initial calls to validate; further calls skip validation.
+        raise_on_error: If True, raise RequirementError on errors; otherwise, only record.
+        record_warnings: If True, attach warnings/errors summary to diag["gcmi_requirements"].
+
+    Returns:
+        A StepFn with early-step requirements validation.
+
+    Notes:
+        - The count is based on wrapper invocations (may include sub-steps if upstream middleware performs substepping).
+        - The wrapper sets __wrapped__ to allow requirement introspection by downstream tooling.
+    """
+    call_count = 0
+
+    def wrapped(state, forcing, params, dt, *, xp):
+        nonlocal call_count
+        reqs = ()
+        errors = []
+        warns = []
+        should_check = call_count < max_checks
+
+        if should_check:
+            reqs = get_requirements(step) + tuple(extra)
+            if reqs:
+                errors, warns = validate_requirements(
+                    state=state, params=params, forcing=forcing, requirements=reqs
+                )
+                if errors and raise_on_error:
+                    # Increment call_count to avoid repeated blocking if caller loops
+                    call_count += 1
+                    raise RequirementError(errors)
+
+        st, diag = step(state, forcing, params, dt, xp=xp)
+
+        if should_check and reqs and record_warnings:
+            if errors or warns:
+                (diag.setdefault("gcmi_requirements", [])).append(
+                    {
+                        "call": call_count,
+                        "max_checks": max_checks,
+                        "checked": len(reqs),
+                        "errors": [
+                            {"where": v.where, "path": v.path, "message": v.message}
+                            for v in errors
+                        ],
+                        "warnings": [
+                            {"where": v.where, "path": v.path, "message": v.message}
+                            for v in warns
+                        ],
+                    }
+                )
+
+        call_count += 1
+        return st, diag
+
+    setattr(wrapped, "__wrapped__", step)
+    return wrapped  # type: ignore[return-value]

--- a/gcmi/utils/requirements.py
+++ b/gcmi/utils/requirements.py
@@ -1,0 +1,218 @@
+"""
+Declarative requirements for GCMI components.
+
+Provides:
+- Requirement: a declarative spec for required keys/values in state/params/forcing
+- requires: decorator to attach Requirement specs to a StepFn or any callable
+- get_requirements: retrieve attached requirements (follows __wrapped__ chain)
+- validate_requirements: runtime validator producing structured violations
+- RequirementError: aggregated error for failing requirements
+
+Intended usage:
+- Authors declare what a step function or middleware needs (e.g. params.spectral.radius).
+- A check middleware (see gcmi.middleware.requirements) enforces these for the
+  first few steps (or always), then skips for performance if desired.
+
+Notes:
+- This module is zero-dependency and does not mutate inputs.
+- Validation does not modify State/Params/Forcing; it only raises or reports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, List, Literal, Mapping, Optional, Sequence, Tuple
+
+Where = Literal["state", "params", "forcing"]
+Severity = Literal["error", "warn"]
+
+
+@dataclass(frozen=True)
+class Requirement:
+    """
+    A declarative requirement on State/Params/Forcing.
+
+    Attributes:
+        where: which container to check ("state" | "params" | "forcing")
+        path: dotted path within that container (e.g., "spectral.radius")
+        required: if True, missing path is a violation
+        type: optional isinstance check (type or tuple of types)
+        predicate: optional predicate(value) -> bool; False is a violation
+        message: optional custom message to display on violation
+        severity: "error" (default) or "warn"
+    """
+
+    where: Where
+    path: str
+    required: bool = True
+    type: Optional[type | tuple[type, ...]] = None
+    predicate: Optional[Callable[[Any], bool]] = None
+    message: Optional[str] = None
+    severity: Severity = "error"
+
+
+@dataclass(frozen=True)
+class Violation:
+    where: Where
+    path: str
+    severity: Severity
+    message: str
+    requirement: Requirement
+
+
+class RequirementError(Exception):
+    """Aggregated requirements error."""
+
+    def __init__(self, violations: Sequence[Violation]) -> None:
+        self.violations = list(violations)
+        msgs = [
+            f"[{v.severity.upper()}] {v.where}.{v.path}: {v.message}"
+            for v in self.violations
+        ]
+        super().__init__("Requirements not satisfied:\n" + "\n".join(msgs))
+
+
+def _get_path(d: Mapping[str, Any], path: str) -> Any:
+    cur: Any = d
+    for seg in path.split("."):
+        if not isinstance(cur, Mapping):
+            raise KeyError(
+                f"Path '{path}' invalid: segment '{seg}' encountered non-mapping type {type(cur).__name__}"
+            )
+        try:
+            cur = cur[seg]  # type: ignore[index]
+        except KeyError as e:
+            raise KeyError(f"Missing key '{seg}' while resolving '{path}'") from e
+    return cur
+
+
+def requires(*reqs: Requirement):
+    """
+    Decorator to attach requirement specs to a function.
+
+    Example:
+        @requires(
+            Requirement("params", "spectral.radius", type=(int, float), predicate=lambda r: r > 0)
+        )
+        def step_fn(...): ...
+
+    The metadata is stored on attribute '__gcmi_requires__' (tuple[Requirement, ...]).
+    """
+
+    def _decorate(fn):
+        existing: Tuple[Requirement, ...] = tuple(getattr(fn, "__gcmi_requires__", ()))
+        setattr(fn, "__gcmi_requires__", existing + tuple(reqs))
+        return fn
+
+    return _decorate
+
+
+def get_requirements(fn: Any) -> Tuple[Requirement, ...]:
+    """
+    Retrieve requirement specs from a function, following __wrapped__ chains if present.
+
+    Returns:
+        A tuple of Requirement instances (may be empty).
+    """
+    reqs: List[Requirement] = []
+    seen: set[int] = set()
+    cur = fn
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        attached = getattr(cur, "__gcmi_requires__", ())
+        if attached:
+            reqs.extend(attached)
+        cur = getattr(cur, "__wrapped__", None)
+    return tuple(reqs)
+
+
+def validate_requirements(
+    *,
+    state: Mapping[str, Any] | None,
+    params: Mapping[str, Any] | None,
+    forcing: Mapping[str, Any] | None,
+    requirements: Sequence[Requirement],
+) -> Tuple[list[Violation], list[Violation]]:
+    """
+    Validate requirements against provided containers.
+
+    Returns:
+        (errors, warnings) as lists of Violation.
+    """
+    errors: list[Violation] = []
+    warns: list[Violation] = []
+
+    def get_container(where: Where) -> Mapping[str, Any] | None:
+        if where == "state":
+            return state
+        if where == "params":
+            return params
+        if where == "forcing":
+            return forcing
+        return None
+
+    for r in requirements:
+        container = get_container(r.where)
+        if container is None:
+            v = Violation(
+                where=r.where,
+                path=r.path,
+                severity=r.severity,
+                message=f"Container '{r.where}' is None; cannot check path '{r.path}'",
+                requirement=r,
+            )
+            (errors if r.severity == "error" else warns).append(v)
+            continue
+
+        try:
+            value = _get_path(container, r.path)
+        except KeyError as e:
+            if r.required:
+                v = Violation(
+                    where=r.where,
+                    path=r.path,
+                    severity=r.severity,
+                    message=r.message or str(e),
+                    requirement=r,
+                )
+                (errors if r.severity == "error" else warns).append(v)
+            # If not required, missing is acceptable; continue.
+            continue
+
+        if r.type is not None and not isinstance(value, r.type):
+            v = Violation(
+                where=r.where,
+                path=r.path,
+                severity=r.severity,
+                message=r.message
+                or f"Expected type {r.type}, got {type(value).__name__}",
+                requirement=r,
+            )
+            (errors if r.severity == "error" else warns).append(v)
+            continue
+
+        if r.predicate is not None:
+            ok = False
+            try:
+                ok = bool(r.predicate(value))
+            except Exception as e:
+                v = Violation(
+                    where=r.where,
+                    path=r.path,
+                    severity=r.severity,
+                    message=r.message or f"Predicate raised: {e}",
+                    requirement=r,
+                )
+                (errors if r.severity == "error" else warns).append(v)
+                continue
+            if not ok:
+                v = Violation(
+                    where=r.where,
+                    path=r.path,
+                    severity=r.severity,
+                    message=r.message or "Predicate returned False",
+                    requirement=r,
+                )
+                (errors if r.severity == "error" else warns).append(v)
+
+    return errors, warns

--- a/gcmi/utils/struct.py
+++ b/gcmi/utils/struct.py
@@ -1,0 +1,122 @@
+"""
+Lightweight, Pythonic helpers for ergonomic Mapping (dict-like) access.
+
+These utilities keep the public API mapping-based (State/Params/Forcing) while
+providing concise, mypy-friendly, and fast access patterns that resemble
+destructuring without introducing dotdicts or heavy dependencies.
+
+Guidelines:
+- Use take/require in hot paths for brevity and speed.
+- Use take_nested for config/params access where dotted paths improve clarity.
+- Avoid silent defaults unless the cfg schema supplies them; prefer explicit KeyError.
+"""
+
+from __future__ import annotations
+
+from operator import itemgetter
+from typing import Any, Mapping, Tuple
+
+__all__ = [
+    "take",
+    "require",
+    "take_nested",
+    "split_keys",
+]
+
+
+def take(d: Mapping[str, Any], *keys: str) -> Tuple[Any, ...]:
+    """
+    Destructure required keys from a mapping in one expression.
+
+    Always returns a tuple of values (length equals the number of keys),
+    so single-key access yields a 1-tuple.
+
+    Example:
+        T, q, u, v = take(state, "T", "q", "u", "v")
+        (dx_min,) = take(params["grid"], "dx_min")
+
+    Raises:
+        KeyError: if any key is missing.
+    """
+    if not keys:
+        return ()
+    if len(keys) == 1:
+        k = keys[0]
+        return (d[k],)
+    return itemgetter(*keys)(d)
+
+
+def require(d: Mapping[str, Any], *keys: str) -> Tuple[Any, ...]:
+    """
+    Like take(), but raises a clearer KeyError message indicating what was expected.
+
+    Example:
+        (dx_min,) = require(params["grid"], "dx_min")
+
+    Raises:
+        KeyError: with an error message listing the missing key and available keys.
+    """
+    if not keys:
+        return ()
+    try:
+        if len(keys) == 1:
+            k = keys[0]
+            return (d[k],)
+        return itemgetter(*keys)(d)
+    except (
+        KeyError
+    ) as e:  # pragma: no cover - error branch is covered by tests via message check
+        missing = e.args[0]
+        raise KeyError(
+            f"Missing required key '{missing}'. Expected one of: {keys}. "
+            f"Available keys: {list(d.keys())}"
+        ) from e
+
+
+def _get_path(d: Mapping[str, Any], path: str) -> Any:
+    cur: Any = d
+    for seg in path.split("."):
+        try:
+            cur = cur[seg]  # type: ignore[index]
+        except KeyError as e:
+            raise KeyError(
+                f"Path segment '{seg}' not found while resolving '{path}'."
+            ) from e
+        except TypeError as e:
+            raise TypeError(
+                f"Encountered non-mapping object at segment '{seg}' while resolving '{path}'. "
+                f"Current object type: {type(cur).__name__}"
+            ) from e
+    return cur
+
+
+def take_nested(d: Mapping[str, Any], *paths: str) -> Tuple[Any, ...]:
+    """
+    Extract multiple dotted-path values from a nested mapping.
+
+    Example:
+        dx_min, theta = take_nested(params, "grid.dx_min", "spectral.semi_implicit.theta")
+
+    Raises:
+        KeyError: if any path segment is missing.
+        TypeError: if an intermediate object is not a Mapping.
+    """
+    return tuple(_get_path(d, p) for p in paths)
+
+
+def split_keys(
+    d: Mapping[str, Any], *keys: str
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """
+    Split a mapping into (picked, rest) by a set of keys.
+
+    Example:
+        picked, rest = split_keys(params, "grid", "backend")
+
+    Note:
+        - Keys must exist in 'd' to be included in 'picked'; missing keys are ignored.
+        - 'rest' preserves all other keys.
+    """
+    picked: dict[str, Any] = {k: d[k] for k in keys if k in d}
+    rest: dict[str, Any] = {k: v for k, v in d.items() if k not in picked}
+    return picked, rest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,22 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "py-gcmi"
 version = "0.1.0"
 description = "The Python general circulation model interface"
 requires-python = ">=3.10"
 dependencies = []
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "ruff>=0.5.0",
+  "black>=24.0.0",
+  "isort>=5.12.0"
+]
+
+[tool.setuptools.packages.find]
+include = ["gcmi*", "pygcmi*"]
+exclude = ["ideas*", "projects*", "docs*", "tests*"]

--- a/tests/middleware/test_requirements_mw.py
+++ b/tests/middleware/test_requirements_mw.py
@@ -1,0 +1,81 @@
+import pytest
+
+from gcmi.middleware.requirements import with_requirements_check
+from gcmi.utils.requirements import Requirement, requires
+
+
+def make_dummy_step(diag_key: str = "ok"):
+    def step(state, forcing, params, dt, *, xp=None):
+        # Pass-through state; emit minimal diag
+        return state, {diag_key: True}
+
+    return step
+
+
+def test_with_requirements_check_raises_on_error_for_first_calls():
+    @requires(
+        Requirement(
+            "params", "spectral.radius", type=(int, float), predicate=lambda r: r > 0
+        )
+    )
+    def step(state, forcing, params, dt, *, xp=None):
+        return state, {}
+
+    wrapped = with_requirements_check(step, max_checks=2, raise_on_error=True)
+
+    # Missing spectral.radius -> should raise on first call
+    with pytest.raises(Exception) as ei:
+        wrapped(state={}, forcing={}, params={}, dt=1.0, xp=None)
+    assert "Requirements not satisfied" in str(ei.value)
+
+
+def test_with_requirements_check_records_warnings_and_skips_after_max_checks():
+    @requires(
+        Requirement(
+            "params", "spectral.radius", type=(int, float), predicate=lambda r: r > 0
+        )
+    )
+    def step(state, forcing, params, dt, *, xp=None):
+        return state, {}
+
+    # Do not raise to allow us to inspect diag; check only first 2 calls
+    wrapped = with_requirements_check(
+        step, max_checks=2, raise_on_error=False, record_warnings=True
+    )
+
+    # Call 1: expect requirements summary with an error entry
+    st1, dg1 = wrapped(state={}, forcing={}, params={}, dt=1.0, xp=None)
+    assert "gcmi_requirements" in dg1
+    assert len(dg1["gcmi_requirements"]) == 1
+    assert dg1["gcmi_requirements"][0]["errors"]
+
+    # Call 2: still within max_checks -> another entry
+    st2, dg2 = wrapped(state={}, forcing={}, params={}, dt=1.0, xp=None)
+    assert "gcmi_requirements" in dg2
+    assert (
+        len(dg2["gcmi_requirements"]) == 1
+    )  # per-call diag only contains its own entry
+
+    # Call 3: beyond max_checks -> no validation/entry
+    st3, dg3 = wrapped(state={}, forcing={}, params={}, dt=1.0, xp=None)
+    assert "gcmi_requirements" not in dg3
+
+
+def test_with_requirements_check_passes_when_requirements_met():
+    @requires(
+        Requirement(
+            "params", "spectral.radius", type=(int, float), predicate=lambda r: r > 0
+        )
+    )
+    def step(state, forcing, params, dt, *, xp=None):
+        return state, {"inner": True}
+
+    wrapped = with_requirements_check(
+        step, max_checks=2, raise_on_error=True, record_warnings=True
+    )
+
+    params = {"spectral": {"radius": 6_371_229.0}}
+    st, dg = wrapped(state={}, forcing={}, params=params, dt=1.0, xp=None)
+    # No errors/warnings recorded when satisfied
+    assert "gcmi_requirements" not in dg
+    assert dg.get("inner") is True

--- a/tests/utils/test_requirements.py
+++ b/tests/utils/test_requirements.py
@@ -1,0 +1,106 @@
+from gcmi.utils.requirements import (
+    Requirement,
+    RequirementError,
+    get_requirements,
+    requires,
+    validate_requirements,
+)
+
+
+def test_validate_requirements_ok_and_types_and_predicate():
+    reqs = [
+        Requirement(
+            "params", "spectral.radius", type=(int, float), predicate=lambda r: r > 0
+        ),
+        Requirement("state", "misc.seed", type=int),
+        Requirement("forcing", "SW"),
+    ]
+    state = {"misc": {"seed": 123}}
+    params = {"spectral": {"radius": 6_371_229.0}}
+    forcing = {"SW": 1.0}
+    errors, warns = validate_requirements(
+        state=state, params=params, forcing=forcing, requirements=reqs
+    )
+    assert errors == []
+    assert warns == []
+
+
+def test_validate_requirements_missing_and_type_violation_and_predicate_violation():
+    reqs = [
+        Requirement(
+            "params", "spectral.radius", type=(int, float), predicate=lambda r: r > 0
+        ),
+        Requirement("params", "grid.dx_min", type=int),  # type mismatch on purpose
+        Requirement("forcing", "LW"),  # missing key
+    ]
+    state = {}
+    params = {
+        "spectral": {"radius": -1.0},
+        "grid": {"dx_min": 1000.0},
+    }  # radius <= 0 and dx_min float
+    forcing = {}
+    errors, warns = validate_requirements(
+        state=state, params=params, forcing=forcing, requirements=reqs
+    )
+    # Expect 3 errors
+    assert len(errors) == 3
+    msgs = "\n".join(v.message for v in errors)
+    assert (
+        "Predicate returned False" in msgs
+        or "Expected type" in msgs
+        or "Missing key" in msgs
+    )
+
+
+def test_requires_decorator_and_get_requirements_collects_chain():
+    @requires(Requirement("params", "spectral.radius", type=(int, float)))
+    def inner(step_state, step_forcing, step_params, dt, *, xp):
+        return step_state, {}
+
+    # Wrap by a simple decorator that preserves __wrapped__
+    def wrapper(fn):
+        def wrapped(*a, **k):
+            return fn(*a, **k)
+
+        setattr(wrapped, "__wrapped__", fn)
+        return wrapped
+
+    wrapped_inner = wrapper(inner)
+
+    reqs = get_requirements(wrapped_inner)
+    assert any(r.where == "params" and r.path == "spectral.radius" for r in reqs)
+
+
+def test_requirement_error_str():
+    violations = [
+        # Craft a minimal Violation-like object using Requirement
+        type(
+            "V",
+            (),
+            {
+                "where": "params",
+                "path": "spectral.radius",
+                "severity": "error",
+                "message": "bad",
+                "requirement": Requirement("params", "spectral.radius"),
+            },
+        )(),
+        type(
+            "V",
+            (),
+            {
+                "where": "forcing",
+                "path": "SW",
+                "severity": "warn",
+                "message": "optional",
+                "requirement": Requirement("forcing", "SW", severity="warn"),
+            },
+        )(),
+    ]
+    err = RequirementError(violations)  # type: ignore[arg-type]
+    s = str(err)
+    assert "Requirements not satisfied" in s
+    assert (
+        "PARAMS.spectral.radius" or "params.spectral.radius"
+    )  # case can vary based on formatting
+    assert "FORCING.SW" or "forcing.SW"

--- a/tests/utils/test_struct.py
+++ b/tests/utils/test_struct.py
@@ -1,0 +1,69 @@
+import pytest
+
+from gcmi.utils.struct import require, split_keys, take, take_nested
+
+
+def test_take_happy_path():
+    state = {"T": 1, "q": 2, "u": 3, "v": 4}
+    T, q, u, v = take(state, "T", "q", "u", "v")
+    assert (T, q, u, v) == (1, 2, 3, 4)
+
+    # Single key still returns a scalar when unpacked as a 1-tuple
+    (T_only,) = take(state, "T")
+    assert T_only == 1
+
+
+def test_take_missing_key_raises_keyerror():
+    state = {"T": 1}
+    with pytest.raises(KeyError):
+        take(state, "T", "q")  # q missing
+
+
+def test_require_happy_path_and_error_message():
+    params = {"grid": {"dx_min": 1000}}
+    (dx_min,) = require(params["grid"], "dx_min")
+    assert dx_min == 1000
+
+    with pytest.raises(KeyError) as ei:
+        require(params["grid"], "dx_min", "dy_min")  # dy_min missing
+    msg = str(ei.value)
+    assert "Missing required key" in msg
+    assert "dy_min" in msg
+    assert "dx_min" in msg  # appears in Expected list
+    assert "Available keys" in msg
+
+
+def test_take_nested_happy_path():
+    params = {
+        "grid": {"dx_min": 1000, "mask": [[1, 0], [0, 1]]},
+        "spectral": {"semi_implicit": {"theta": 0.5}},
+    }
+    dx_min, theta = take_nested(params, "grid.dx_min", "spectral.semi_implicit.theta")
+    assert dx_min == 1000
+    assert theta == 0.5
+
+
+def test_take_nested_missing_key_raises_keyerror():
+    params = {"grid": {"dx_min": 1000}}
+    with pytest.raises(KeyError) as ei:
+        take_nested(params, "grid.dy_min")
+    assert "dy_min" in str(ei.value)
+
+
+def test_take_nested_type_error_on_non_mapping():
+    params = {"grid": {"dx_min": 1000}}
+    # grid.dx_min is an int; asking for another segment should raise TypeError
+    with pytest.raises(TypeError) as ei:
+        take_nested(params, "grid.dx_min.value")
+    assert "non-mapping object" in str(ei.value)
+
+
+def test_split_keys_basic():
+    params = {
+        "grid": {"dx_min": 1000},
+        "backend": {"xp": "numpy"},
+        "energy_budget": {"target_total": 42.0},
+    }
+    picked, rest = split_keys(params, "grid", "backend", "nonexistent")
+    assert picked == {"grid": {"dx_min": 1000}, "backend": {"xp": "numpy"}}
+    assert rest == {"energy_budget": {"target_total": 42.0}}

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,266 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "black"
+version = "25.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/43/20b5c90612d7bdb2bdbcceeb53d588acca3bb8f0e4c5d5c751a2c8fdd55a/black-25.9.0.tar.gz", hash = "sha256:0474bca9a0dd1b51791fcc507a4e02078a1c63f6d4e4ae5544b9848c7adfb619", size = 648393, upload-time = "2025-09-19T00:27:37.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/40/dbe31fc56b218a858c8fc6f5d8d3ba61c1fa7e989d43d4a4574b8b992840/black-25.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ce41ed2614b706fd55fd0b4a6909d06b5bab344ffbfadc6ef34ae50adba3d4f7", size = 1715605, upload-time = "2025-09-19T00:36:13.483Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b2/f46800621200eab6479b1f4c0e3ede5b4c06b768e79ee228bc80270bcc74/black-25.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2ab0ce111ef026790e9b13bd216fa7bc48edd934ffc4cbf78808b235793cbc92", size = 1571829, upload-time = "2025-09-19T00:32:42.13Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/64/5c7f66bd65af5c19b4ea86062bb585adc28d51d37babf70969e804dbd5c2/black-25.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f96b6726d690c96c60ba682955199f8c39abc1ae0c3a494a9c62c0184049a713", size = 1631888, upload-time = "2025-09-19T00:30:54.212Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/64/0b9e5bfcf67db25a6eef6d9be6726499a8a72ebab3888c2de135190853d3/black-25.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:d119957b37cc641596063cd7db2656c5be3752ac17877017b2ffcdb9dfc4d2b1", size = 1327056, upload-time = "2025-09-19T00:31:08.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f4/7531d4a336d2d4ac6cc101662184c8e7d068b548d35d874415ed9f4116ef/black-25.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:456386fe87bad41b806d53c062e2974615825c7a52159cde7ccaeb0695fa28fa", size = 1698727, upload-time = "2025-09-19T00:31:14.264Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f9/66f26bfbbf84b949cc77a41a43e138d83b109502cd9c52dfc94070ca51f2/black-25.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a16b14a44c1af60a210d8da28e108e13e75a284bf21a9afa6b4571f96ab8bb9d", size = 1555679, upload-time = "2025-09-19T00:31:29.265Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/59/61475115906052f415f518a648a9ac679d7afbc8da1c16f8fdf68a8cebed/black-25.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aaf319612536d502fdd0e88ce52d8f1352b2c0a955cc2798f79eeca9d3af0608", size = 1617453, upload-time = "2025-09-19T00:30:42.24Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5b/20fd5c884d14550c911e4fb1b0dae00d4abb60a4f3876b449c4d3a9141d5/black-25.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:c0372a93e16b3954208417bfe448e09b0de5cc721d521866cd9e0acac3c04a1f", size = 1333655, upload-time = "2025-09-19T00:30:56.715Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/8e/319cfe6c82f7e2d5bfb4d3353c6cc85b523d677ff59edc61fdb9ee275234/black-25.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1b9dc70c21ef8b43248f1d86aedd2aaf75ae110b958a7909ad8463c4aa0880b0", size = 1742012, upload-time = "2025-09-19T00:33:08.678Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cc/f562fe5d0a40cd2a4e6ae3f685e4c36e365b1f7e494af99c26ff7f28117f/black-25.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8e46eecf65a095fa62e53245ae2795c90bdecabd53b50c448d0a8bcd0d2e74c4", size = 1581421, upload-time = "2025-09-19T00:35:25.937Z" },
+    { url = "https://files.pythonhosted.org/packages/84/67/6db6dff1ebc8965fd7661498aea0da5d7301074b85bba8606a28f47ede4d/black-25.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9101ee58ddc2442199a25cb648d46ba22cd580b00ca4b44234a324e3ec7a0f7e", size = 1655619, upload-time = "2025-09-19T00:30:49.241Z" },
+    { url = "https://files.pythonhosted.org/packages/10/10/3faef9aa2a730306cf469d76f7f155a8cc1f66e74781298df0ba31f8b4c8/black-25.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:77e7060a00c5ec4b3367c55f39cf9b06e68965a4f2e61cecacd6d0d9b7ec945a", size = 1342481, upload-time = "2025-09-19T00:31:29.625Z" },
+    { url = "https://files.pythonhosted.org/packages/48/99/3acfea65f5e79f45472c45f87ec13037b506522719cd9d4ac86484ff51ac/black-25.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0172a012f725b792c358d57fe7b6b6e8e67375dd157f64fa7a3097b3ed3e2175", size = 1742165, upload-time = "2025-09-19T00:34:10.402Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/18/799285282c8236a79f25d590f0222dbd6850e14b060dfaa3e720241fd772/black-25.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3bec74ee60f8dfef564b573a96b8930f7b6a538e846123d5ad77ba14a8d7a64f", size = 1581259, upload-time = "2025-09-19T00:32:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ce/883ec4b6303acdeca93ee06b7622f1fa383c6b3765294824165d49b1a86b/black-25.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b756fc75871cb1bcac5499552d771822fd9db5a2bb8db2a7247936ca48f39831", size = 1655583, upload-time = "2025-09-19T00:30:44.505Z" },
+    { url = "https://files.pythonhosted.org/packages/21/17/5c253aa80a0639ccc427a5c7144534b661505ae2b5a10b77ebe13fa25334/black-25.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:846d58e3ce7879ec1ffe816bb9df6d006cd9590515ed5d17db14e17666b2b357", size = 1343428, upload-time = "2025-09-19T00:32:13.839Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/46/863c90dcd3f9d41b109b7f19032ae0db021f0b2a81482ba0a1e28c84de86/black-25.9.0-py3-none-any.whl", hash = "sha256:474b34c1342cdc157d307b56c4c65bce916480c4a8f6551fdc6bf9b486a7c4ae", size = 203363, upload-time = "2025-09-19T00:27:35.724Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "isort"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/21/1e2a441f74a653a144224d7d21afe8f4169e6c7c20bb13aec3a2dc3815e0/isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450", size = 821955, upload-time = "2025-02-26T21:13:16.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/11/114d0a5f4dabbdcedc1125dee0888514c3c3b16d3e9facad87ed96fad97c/isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615", size = 94186, upload-time = "2025-02-26T21:13:14.911Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "py-gcmi"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.optional-dependencies]
+dev = [
+    { name = "black" },
+    { name = "isort" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
+    { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/5f/e959a442435e24f6fb5a01aec6c657079ceaca1b3baf18561c3728d681da/pytokens-0.1.10.tar.gz", hash = "sha256:c9a4bfa0be1d26aebce03e6884ba454e842f186a59ea43a6d3b25af58223c044", size = 12171, upload-time = "2025-02-19T14:51:22.001Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/e5/63bed382f6a7a5ba70e7e132b8b7b8abbcf4888ffa6be4877698dcfbed7d/pytokens-0.1.10-py3-none-any.whl", hash = "sha256:db7b72284e480e69fb085d9f251f66b3d2df8b7166059261258ff35f50fb711b", size = 12046, upload-time = "2025-02-19T14:51:18.694Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/33/c8e89216845615d14d2d42ba2bee404e7206a8db782f33400754f3799f05/ruff-0.13.1.tar.gz", hash = "sha256:88074c3849087f153d4bb22e92243ad4c1b366d7055f98726bc19aa08dc12d51", size = 5397987, upload-time = "2025-09-18T19:52:44.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/41/ca37e340938f45cfb8557a97a5c347e718ef34702546b174e5300dbb1f28/ruff-0.13.1-py3-none-linux_armv6l.whl", hash = "sha256:b2abff595cc3cbfa55e509d89439b5a09a6ee3c252d92020bd2de240836cf45b", size = 12304308, upload-time = "2025-09-18T19:51:56.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/84/ba378ef4129415066c3e1c80d84e539a0d52feb250685091f874804f28af/ruff-0.13.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4ee9f4249bf7f8bb3984c41bfaf6a658162cdb1b22e3103eabc7dd1dc5579334", size = 12937258, upload-time = "2025-09-18T19:52:00.184Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b6/ec5e4559ae0ad955515c176910d6d7c93edcbc0ed1a3195a41179c58431d/ruff-0.13.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5c5da4af5f6418c07d75e6f3224e08147441f5d1eac2e6ce10dcce5e616a3bae", size = 12214554, upload-time = "2025-09-18T19:52:02.753Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d6/cb3e3b4f03b9b0c4d4d8f06126d34b3394f6b4d764912fe80a1300696ef6/ruff-0.13.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:80524f84a01355a59a93cef98d804e2137639823bcee2931f5028e71134a954e", size = 12448181, upload-time = "2025-09-18T19:52:05.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ea/bf60cb46d7ade706a246cd3fb99e4cfe854efa3dfbe530d049c684da24ff/ruff-0.13.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ff7f5ce8d7988767dd46a148192a14d0f48d1baea733f055d9064875c7d50389", size = 12104599, upload-time = "2025-09-18T19:52:07.497Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/3e/05f72f4c3d3a69e65d55a13e1dd1ade76c106d8546e7e54501d31f1dc54a/ruff-0.13.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c55d84715061f8b05469cdc9a446aa6c7294cd4bd55e86a89e572dba14374f8c", size = 13791178, upload-time = "2025-09-18T19:52:10.189Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e7/01b1fc403dd45d6cfe600725270ecc6a8f8a48a55bc6521ad820ed3ceaf8/ruff-0.13.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:ac57fed932d90fa1624c946dc67a0a3388d65a7edc7d2d8e4ca7bddaa789b3b0", size = 14814474, upload-time = "2025-09-18T19:52:12.866Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/92/d9e183d4ed6185a8df2ce9faa3f22e80e95b5f88d9cc3d86a6d94331da3f/ruff-0.13.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c366a71d5b4f41f86a008694f7a0d75fe409ec298685ff72dc882f882d532e36", size = 14217531, upload-time = "2025-09-18T19:52:15.245Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4a/6ddb1b11d60888be224d721e01bdd2d81faaf1720592858ab8bac3600466/ruff-0.13.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f4ea9d1b5ad3e7a83ee8ebb1229c33e5fe771e833d6d3dcfca7b77d95b060d38", size = 13265267, upload-time = "2025-09-18T19:52:17.649Z" },
+    { url = "https://files.pythonhosted.org/packages/81/98/3f1d18a8d9ea33ef2ad508f0417fcb182c99b23258ec5e53d15db8289809/ruff-0.13.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0f70202996055b555d3d74b626406476cc692f37b13bac8828acff058c9966a", size = 13243120, upload-time = "2025-09-18T19:52:20.332Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/86/b6ce62ce9c12765fa6c65078d1938d2490b2b1d9273d0de384952b43c490/ruff-0.13.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:f8cff7a105dad631085d9505b491db33848007d6b487c3c1979dd8d9b2963783", size = 13443084, upload-time = "2025-09-18T19:52:23.032Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/6e/af7943466a41338d04503fb5a81b2fd07251bd272f546622e5b1599a7976/ruff-0.13.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9761e84255443316a258dd7dfbd9bfb59c756e52237ed42494917b2577697c6a", size = 12295105, upload-time = "2025-09-18T19:52:25.263Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/97/0249b9a24f0f3ebd12f007e81c87cec6d311de566885e9309fcbac5b24cc/ruff-0.13.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:3d376a88c3102ef228b102211ef4a6d13df330cb0f5ca56fdac04ccec2a99700", size = 12072284, upload-time = "2025-09-18T19:52:27.478Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/85/0b64693b2c99d62ae65236ef74508ba39c3febd01466ef7f354885e5050c/ruff-0.13.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:cbefd60082b517a82c6ec8836989775ac05f8991715d228b3c1d86ccc7df7dae", size = 12970314, upload-time = "2025-09-18T19:52:30.212Z" },
+    { url = "https://files.pythonhosted.org/packages/96/fc/342e9f28179915d28b3747b7654f932ca472afbf7090fc0c4011e802f494/ruff-0.13.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:dd16b9a5a499fe73f3c2ef09a7885cb1d97058614d601809d37c422ed1525317", size = 13422360, upload-time = "2025-09-18T19:52:32.676Z" },
+    { url = "https://files.pythonhosted.org/packages/37/54/6177a0dc10bce6f43e392a2192e6018755473283d0cf43cc7e6afc182aea/ruff-0.13.1-py3-none-win32.whl", hash = "sha256:55e9efa692d7cb18580279f1fbb525146adc401f40735edf0aaeabd93099f9a0", size = 12178448, upload-time = "2025-09-18T19:52:35.545Z" },
+    { url = "https://files.pythonhosted.org/packages/64/51/c6a3a33d9938007b8bdc8ca852ecc8d810a407fb513ab08e34af12dc7c24/ruff-0.13.1-py3-none-win_amd64.whl", hash = "sha256:3a3fb595287ee556de947183489f636b9f76a72f0fa9c028bdcabf5bab2cc5e5", size = 13286458, upload-time = "2025-09-18T19:52:38.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/04/afc078a12cf68592345b1e2d6ecdff837d286bac023d7a22c54c7a698c5b/ruff-0.13.1-py3-none-win_arm64.whl", hash = "sha256:c0bae9ffd92d54e03c2bf266f466da0a65e145f298ee5b5846ed435f6a00518a", size = 12437893, upload-time = "2025-09-18T19:52:41.283Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429, upload-time = "2024-11-27T22:37:56.698Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067, upload-time = "2024-11-27T22:37:57.63Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030, upload-time = "2024-11-27T22:37:59.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898, upload-time = "2024-11-27T22:38:00.429Z" },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894, upload-time = "2024-11-27T22:38:02.094Z" },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319, upload-time = "2024-11-27T22:38:03.206Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273, upload-time = "2024-11-27T22:38:04.217Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310, upload-time = "2024-11-27T22:38:05.908Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309, upload-time = "2024-11-27T22:38:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762, upload-time = "2024-11-27T22:38:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453, upload-time = "2024-11-27T22:38:09.384Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486, upload-time = "2024-11-27T22:38:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349, upload-time = "2024-11-27T22:38:11.443Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159, upload-time = "2024-11-27T22:38:13.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243, upload-time = "2024-11-27T22:38:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645, upload-time = "2024-11-27T22:38:15.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584, upload-time = "2024-11-27T22:38:17.645Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875, upload-time = "2024-11-27T22:38:19.159Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418, upload-time = "2024-11-27T22:38:20.064Z" },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708, upload-time = "2024-11-27T22:38:21.659Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582, upload-time = "2024-11-27T22:38:22.693Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543, upload-time = "2024-11-27T22:38:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691, upload-time = "2024-11-27T22:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170, upload-time = "2024-11-27T22:38:27.921Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530, upload-time = "2024-11-27T22:38:29.591Z" },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666, upload-time = "2024-11-27T22:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954, upload-time = "2024-11-27T22:38:31.702Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
This PR squashes all changes from chore/ci-docs-requirements into a single commit for a clean history.

Includes:
- docs: plan.md and design.md (English), ergonomic dict handling & declarative requirements sections
- utils: mapping ergonomics helpers (gcmi/utils/struct.py) + tests
- utils+mw: declarative requirements API and early-check middleware + tests
- AGENTS.md: sections 3.1.1 and 3.1.2
- dev tooling: pytest, ruff, black, isort in pyproject; build-system + package discovery fix
- CI: GitHub Actions workflow (uv + ruff + pytest)

Supersedes the previous PR.