### PR TITLE
feat: WSGI-like minimal driver + core docs + minimal tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,4 +207,7 @@ marimo/_lsp/
 __marimo__/
 
 .idea/
+.vscode/
+
 ideas/
+vendors/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,80 @@
 # py-gcmi
 
 The Python reference implementation of GCMI, with core APIs, middleware, hooks, and examples.
+
+WSGI-inspired minimal usage
+- Like WSGI’s tiny app(environ, start_response) and server loop, GCMI offers a tiny step callable and a minimal driver to run it.
+- Goal: make the “hello world” path trivial and elegant to encourage incremental assembly.
+
+Quick start (minimal, WSGI-like)
+- Requirements: Python ≥ 3.10
+- Clone the repo, then run the minimal example:
+
+```bash
+python examples/gcmi_minimal_driver.py
+```
+
+You should see:
+- CSV lines of per-step timing (k, step_sec) printed by the timing hook
+- Final state and an average step time summary
+
+Minimal “hello world” for GCMI
+This is the closest analogue to a WSGI hello world.
+
+```python
+import sys
+import numpy as np
+from typing import Any, Dict, Tuple
+
+from gcmi.drivers import run
+from gcmi.hooks.timing import timer_hook
+
+def step(state: Dict[str, Any], forcing: Dict[str, Any], params: Dict[str, Any], dt: float, *, xp: Any) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    # Identity physics: pass state through, return minimal diag
+    return state, {"gcmi_mw": []}
+
+xp = np
+cfg = {
+    "state0": {"T": xp.array(300.0)},
+    "params": {"time": {"dt": 1.0}},
+}
+forcing_stream = lambda k: {}  # empty forcing
+hook = timer_hook(sink=sys.stdout, fmt="csv")
+
+final_state, report = run(
+    step,
+    cfg=cfg,
+    xp=xp,
+    forcing_stream=forcing_stream,
+    n_steps=5,
+    hooks=(hook,),
+)
+print("Final state:", {k: (v.tolist() if hasattr(v, "tolist") else v) for k, v in final_state.items()})
+```
+
+Where the pieces map (WSGI → GCMI)
+- app(environ, start_response) → step(state, forcing, params, dt, *, xp)
+- make_server(..., app).serve_forever() → run(step, cfg=..., xp=..., forcing_stream=..., n_steps=..., hooks=...)
+- WSGI middleware → GCMI middleware (functional wrappers around step); hooks are observational
+
+Repository guide
+- Core API: gcmi/core/api.py (init_fn, step_fn, run_fn)
+- Minimal driver (WSGI-like): gcmi/drivers/ (StepCallable, make_runner, run)
+- Hooks: gcmi/hooks/ (e.g., timer_hook)
+- Examples:
+  - examples/wsgi_minimal.py (reference WSGI hello)
+  - examples/gcmi_minimal.py (uses core.run_fn; shows rebinding step_fn)
+  - examples/gcmi_minimal_driver.py (WSGI-like one-shot run helper)
+- Design & Plan:
+  - docs/design.md (Core contracts, middleware, hooks, ops)
+  - docs/plan.md (Milestones M0–M4)
+
+Next steps (after hello world)
+- Add a custom step for tiny tendencies (see examples/gcmi_minimal.py for a simple _custom_step)
+- Wrap with middleware: CFL guards, positivity, flux limiters, energy fix
+- Attach more hooks: energy/water budgets, spectra (if SpectralOps is enabled)
+- Move from NumPy to JAX/Torch by swapping xp without changing the step contract
+
+Contributing
+- See AGENTS.md for engineering protocols (ruff, black, isort, mypy --strict, pytest, pre-commit)
+- Keep changes small and atomic with tests and doc updates

--- a/examples/minimal.py
+++ b/examples/minimal.py
@@ -1,0 +1,37 @@
+"""
+A minimal GCMI example using the tiny driver API.
+
+Goal: make the "hello world" for GCMI as elegant as possible.
+Here:
+  - You write a tiny step(dt, state, forcing, params, *, xp) -> (state, diag)
+  - You call run(step, cfg=..., forcing_stream=..., n_steps=..., hooks=..., xp=...)
+  - That's it.
+
+This mirrors the WSGI style and avoids rebinding module-level step_fn.
+"""
+
+from typing import Any, Dict, Tuple
+
+import numpy as xp  # could be jax.numpy, cupy, etc.
+
+from gcmi.drivers import run
+
+
+def step(
+    dt: float,
+    state: Dict[str, Any],
+    *,
+    xp: Any,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    return state, {}
+
+
+if __name__ == "__main__":
+    final_state, report = run(
+        step,
+        n_steps=5,
+        xp=xp
+    )
+    print("Final state:", final_state)
+    print("Report:", report)
+

--- a/gcmi/__init__.py
+++ b/gcmi/__init__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from . import hooks, middleware, ops
+from .core.api import init_fn, run_fn, step_fn
+
+__all__ = [
+    "init_fn",
+    "run_fn",
+    "step_fn",
+    "middleware",
+    "hooks",
+    "ops",
+]
+
+# Keep in sync with pyproject.toml [project].version
+__version__ = "0.1.0"

--- a/gcmi/core/api.py
+++ b/gcmi/core/api.py
@@ -1,10 +1,80 @@
-from typing import Any, Callable, Dict, Mapping, Protocol, Tuple
+"""GCMI Core API (Python reference)
+
+This module defines the strict, backend‑neutral contracts used by py-gcmi.
+
+Key type aliases (Mappings of string keys to array-like values/metadata)
+- State: Dict[str, ArrayLike]
+    The prognostic variables that evolve in time and are advanced by the step
+    function each iteration (e.g., "T", "q", "u", "v"). State holds the model's
+    instantaneous fields. Step functions read State and must return the next
+    State (a dict with the same conceptual structure). State values are
+    backend-aware arrays (NumPy/JAX/Torch-like), but the container is a plain
+    Python dict for ergonomic access, composition, and typing.
+
+- Forcing: Dict[str, ArrayLike]
+    External, time‑varying inputs that are not advanced by the model (e.g.,
+    prescribed heating/cooling, fixed topography masks when streamed, idealized
+    source/sink terms). Forcing is supplied per step by a forcing_stream and
+    read by the step function; a step may ignore it.
+
+- Params: Mapping[str, Any]
+    Runtime constants/configuration (e.g., grid geometry, physical constants,
+    time configuration like {"time":{"dt":...}}, backend capability records,
+    ops adapters). Params are conceptually read‑only during a run (treat them
+    as constants for reproducibility and clarity). init_fn is responsible for
+    constructing Params from a configuration mapping and for recording the
+    selected backend namespace under params["backend"]["xp"].
+
+- Diag: Dict[str, Any]
+    Per‑step diagnostics and metadata emitted by the step function and/or
+    wrappers. Hooks and drivers may consume these entries for logging and
+    observability (e.g., timings, budget summaries, middleware metadata).
+    By convention, middleware may append metadata under diag["gcmi_mw"] (list)
+    for auditability, but this is not strictly required in minimal demos.
+
+Assembly and execution flow
+1) Configuration → Initialization:
+   A high‑level cfg (environment/config mapping) is passed to init_fn(cfg, xp=...)
+   which returns (state0, params). The function injects the backend namespace
+   into params["backend"]["xp"] so downstream code can discover the numerical
+   backend (NumPy/JAX/Torch) without global state.
+
+2) Stepping contract (StepFn):
+   step(state, forcing, params, dt, *, xp) -> (state, diag)
+   - Pure and stateless (no hidden globals); must return a new State and a Diag.
+   - Middleware composes as (StepFn)->StepFn and may add Diag metadata.
+
+3) Run loop:
+   run_fn(init_state, params, forcing_stream, xp=..., n_steps=..., hooks=...)
+   - Iterates n_steps; each iteration pulls a Forcing from forcing_stream.
+   - Calls step(...) and measures per‑step wall time, attaching
+     diag["timings"]["step_sec"].
+   - Invokes hooks as hook(k, state, diag, params=?, xp=?). Hooks are strictly
+     observational and must not mutate State/Params.
+
+4) Timestep (dt):
+   The core run loop reads dt from params["time"]["dt"] if present; otherwise
+   defaults to 1.0. Drivers may offer convenience overrides, but Core keeps this
+   simple rule for clarity and determinism.
+
+Why dict-based containers?
+- Dicts make required keys explicit, enable composable middleware and hooks, and
+  keep the public API backend‑neutral. TypedDict/NamedTuple views can be layered
+  for developer ergonomics, while runtime objects remain plain dicts for speed
+  and simplicity.
+"""
+from __future__ import annotations
+
+from time import perf_counter
+from typing import (Any, Callable, Dict, Iterable, Iterator, Mapping, Protocol,
+                    Tuple, Union, cast)
 
 
+# Protocols for backend-neutral array namespace (numpy/jax.numpy/torch-like)
 class ArrayLike(Protocol): ...
 
 
-class XP(Protocol): ...
+class XP(Protocol): ...  # numpy, jax.numpy, torch-like
 
 
 State = Dict[str, ArrayLike]
@@ -15,16 +85,179 @@ Diag = Dict[str, Any]
 StepFn = Callable[[State, Forcing, Params, float], Tuple[State, Diag]]
 
 
-def init_fn(cfg: Mapping[str, Any], *, xp: XP) -> Tuple[State, Params]: ...
+# Module-level step function (can be wrapped by middleware from callers)
+# Default "identity physics": pass-through with empty diag.
 def step_fn(
     state: State, forcing: Forcing, params: Params, dt: float, *, xp: XP
-) -> Tuple[State, Diag]: ...
+) -> Tuple[State, Diag]:
+    """
+    Core step function: advance the model State by one time step.
+
+    Semantics
+    - Reads the current State and optional Forcing along with immutable Params
+      and a scalar timestep dt; returns the next State and a Diag mapping.
+    - Pure function contract: no hidden global state, reproducible from inputs.
+    - Backend-neutral: xp is a keyword-only namespace (numpy/jax.numpy/torch-like).
+
+    This default implementation is an identity mapping suited for wiring tests
+    and minimal examples. Real models SHOULD replace or wrap this via middleware
+    assembly to implement physics/dynamics tendencies.
+
+    Inputs
+    - state: Dict[str, ArrayLike]   (prognostic fields to be advanced)
+    - forcing: Dict[str, ArrayLike] (external inputs for this step; may be empty)
+    - params: Mapping[str, Any]     (runtime constants/config; read-only)
+    - dt: float                     (timestep length in seconds or model units)
+    - xp: XP                        (array namespace for backend operations)
+
+    Outputs
+    - (next_state, diag)
+      next_state: Dict[str, ArrayLike] (may alias inputs if updates are in-place
+      within backend semantics, but must honor the functional contract)
+      diag: Dict[str, Any]             (step-level diagnostics/metadata; middleware
+      often appends under diag["gcmi_mw"], and the run loop attaches timings)
+
+    Notes
+    - Hooks must treat diag as read-only; only middleware/step compose diag content.
+    """
+    # Minimal diag structure for downstream hooks/middleware
+    diag: Diag = {"gcmi_mw": []}
+    return state, diag
+
+
+def init_fn(cfg: Mapping[str, Any], *, xp: XP) -> Tuple[State, Params]:
+    """
+    Initialize (state0, params) from a configuration mapping.
+
+    Purpose
+    - Normalize a high-level configuration (cfg) into the two core runtime
+      containers used by the step/run loop: State and Params.
+    - Record the numerical backend namespace under params["backend"]["xp"].
+
+    Expected cfg keys (soft contract; schema validation is external to Core)
+    - "state0": optional mapping for initial state arrays, e.g. {"T": xp.array(...)}
+    - "params": optional mapping for runtime constants/config; this function
+      injects the backend as params["backend"]["xp"] = xp.
+
+    Returns
+    - (state0, params)
+      state0: Dict[str, ArrayLike]   (prognostic arrays at initial time)
+      params: Mapping[str, Any]      (constants/config; includes backend xp)
+
+    Notes
+    - This function performs minimal shaping and does not validate schemas; a
+      stricter loader/validator (e.g., pydantic) can wrap cfg ahead of this call.
+    """
+    state0_raw = cast(Mapping[str, Any], cfg.get("state0", {}))
+    params_raw = dict(cast(Mapping[str, Any], cfg.get("params", {})))
+
+    # Ensure a backend namespace record exists
+    backend = dict(cast(Mapping[str, Any], params_raw.get("backend", {})))
+    backend["xp"] = xp
+    params_raw["backend"] = backend
+
+    # Shallow copy of state; callers may convert to device arrays in their own init
+    state0: State = dict(state0_raw)  # type: ignore[assignment]
+    params: Params = params_raw
+    return state0, params
+
+
+def _as_iter(
+    forcing_stream: Union[
+        Iterable[Forcing], Iterator[Forcing], Callable[[int], Forcing]
+    ],
+) -> Iterator[Forcing]:
+    if callable(forcing_stream):
+        k = 0
+
+        def gen() -> Iterator[Forcing]:
+            nonlocal k
+            while True:
+                yield cast(Forcing, forcing_stream(k))
+                k += 1
+
+        return gen()
+    if hasattr(forcing_stream, "__iter__"):
+        return iter(cast(Iterable[Forcing], forcing_stream))
+    raise TypeError(
+        "forcing_stream must be an Iterable[Forcing] or Callable[[int], Forcing]"
+    )
+
+
 def run_fn(
     init: State,
     params: Params,
-    forcing_stream,
+    forcing_stream: Union[
+        Iterable[Forcing], Iterator[Forcing], Callable[[int], Forcing]
+    ],
     *,
     xp: XP,
     n_steps: int,
     hooks: Tuple[Callable[[int, State, Diag], None], ...] = (),
-) -> Tuple[State, Mapping[str, Any]]: ...
+) -> Tuple[State, Mapping[str, Any]]:
+    """
+    Execute the core run loop for n_steps and invoke observational hooks.
+
+    Behavior
+    - Iteratively:
+      1) obtain a Forcing from forcing_stream (iterable/iterator/callable(k)),
+      2) call step_fn(state, forcing, params, dt, xp=xp),
+      3) measure per-step wall time and attach diag["timings"]["step_sec"],
+      4) call each hook(k, state, diag, ...) strictly as an observer.
+
+    Inputs
+    - init:   initial State (from init_fn or user-constructed)
+    - params: runtime constants/config (includes params["backend"]["xp"] = xp)
+    - forcing_stream: produces Forcing per step ({} is acceptable if unused)
+    - xp: backend namespace (NumPy/JAX/Torch-like)
+    - n_steps: number of time steps to execute
+    - hooks: tuple of callables observing (k, state, diag). Hooks must not mutate.
+
+    Timestep (dt)
+    - Resolved from params["time"]["dt"] if present; otherwise defaults to 1.0.
+
+    Returns
+    - (final_state, report)
+      final_state: State after n_steps
+      report: Mapping with aggregates (e.g., {"timings":{"per_step_sec":[...]},"last_diag":...})
+
+    Notes
+    - The run loop uses the module-level step_fn. To use a custom assembled step
+      (e.g., with middleware), either rebind gcmi.core.api.step_fn or call your
+      own assembled step directly from a custom loop/driver.
+    """
+    # Ensure step_fn is callable with the expected signature
+    step = cast(Callable[[State, Forcing, Params, float], Tuple[State, Diag]], step_fn)
+
+    st: State = init
+    report: Dict[str, Any] = {"timings": {"per_step_sec": []}, "last_diag": None}
+
+    # Provide a default dt if not supplied via params; examples can override
+    dt = cast(float, cast(Mapping[str, Any], params.get("time", {})).get("dt", 1.0))
+
+    fiter = _as_iter(forcing_stream)
+
+    for k in range(n_steps):
+        forcing = next(fiter, {})
+        t0 = perf_counter()
+        st, diag = step(st, forcing, params, dt, xp=xp)
+        t1 = perf_counter()
+
+        # Timing
+        dur = t1 - t0
+        # Attach per-step timing into diag for hook consumption
+        (diag.setdefault("timings", {}))["step_sec"] = dur
+        report["timings"]["per_step_sec"].append(dur)
+
+        # Invoke hooks (observational only)
+        for hook in hooks:
+            # Pass-through extra kwargs for richer hook signatures
+            try:
+                hook(k, st, diag)  # type: ignore[misc]
+            except TypeError:
+                # Support hooks that expect named params/xp as described in design
+                hook(k, st, diag, params=params, xp=xp)  # type: ignore[misc]
+
+        report["last_diag"] = diag
+
+    return st, report

--- a/gcmi/drivers/__init__.py
+++ b/gcmi/drivers/__init__.py
@@ -1,0 +1,27 @@
+"""Drivers entrypoint exposing a WSGI-like minimal runner API for GCMI.
+
+WSGI analogy:
+- app(environ, start_response)                    ~ step(state, forcing, params, dt, *, xp)
+- make_server(host, port, app).serve_forever()    ~ make_runner(step, cfg, xp).run(forcing, n_steps)
+
+Public API:
+- StepCallable: protocol for step callables
+- make_runner: bind step+cfg+xp(+hooks) to create a small runner callable
+- run: one-shot helper to init and execute a run
+
+Example:
+    import numpy as np
+    from gcmi.drivers import StepCallable, run
+
+    def step(state, forcing, params, dt, *, xp):
+        return state, {"gcmi_mw": []}
+
+    cfg = {"state0": {"T": np.array(300.0)}, "params": {"time": {"dt": 1.0}}}
+    final_state, report = run(step, cfg=cfg, xp=np, forcing_stream=lambda k: {}, n_steps=5)
+"""
+
+from __future__ import annotations
+
+from .minimal import StepCallable, make_runner, run
+
+__all__ = ["StepCallable", "make_runner", "run"]

--- a/gcmi/drivers/minimal.py
+++ b/gcmi/drivers/minimal.py
@@ -1,0 +1,224 @@
+"""Minimal driver utilities to make GCMI usage feel as simple as WSGI.
+
+WSGI analogy:
+- app(environ, start_response)                    ~ step(dt, state, forcing, params, *, xp)
+- make_server(host, port, app).serve_forever()    ~ run(step, n_steps, xp, cfg=?, forcing_stream=?, hooks=?)
+
+Design goals
+- Keep Core strict and stable (for middleware/hooks/tests), while Drivers offer a
+  "sugar" layer with sensible defaults and flexible step signatures for minimal demos.
+- Defaults allow a true 20-line "Hello, GCMI" script.
+
+Public (Driver) API
+- run(
+    step,
+    *,
+    n_steps: int,
+    xp,
+    cfg: Mapping[str, Any] | None = None,
+    forcing_stream: ForcingStream | None = None,
+    hooks: tuple[Hook, ...] = (),
+    dt: float | None = None,
+  ) -> tuple[State, Mapping[str, Any]]
+
+- make_runner(step, *, xp, cfg=None, hooks=(), dt=None) -> (forcing_stream, n_steps) -> (state, report)
+
+Step signature flexibility (Driver level)
+- Preferred minimal:   step(dt, state, *, xp) -> (state, diag)
+- Also accepted:       step(dt, state, forcing=None, *, xp) / step(dt, state, forcing=None, params=None, *, xp)
+- Back-compatible:     step(state, forcing, params, dt, *, xp)
+- The driver inspects available parameter names and passes only what the function accepts.
+"""
+
+from __future__ import annotations
+
+import inspect
+from time import perf_counter
+from typing import (Any, Callable, Iterable, Iterator, Mapping, Protocol, Tuple, Union)
+
+from gcmi.core.api import XP, Diag, Forcing, Params, State, init_fn
+
+# Hook signature (observational only) aligned with core hooks
+Hook = Callable[[int, dict[str, Any], dict[str, Any]], None]
+
+
+class StepCallable(Protocol):
+    """Callable contract for a GCMI step function (flexible at Driver level).
+
+    Implementations may use any of the accepted signatures (see module docstring).
+    The driver will adapt calls by name (dt/state/forcing/params/xp) and only pass
+    those the function actually declares.
+    """
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Tuple[State, Diag]: ...
+
+
+# Accepted forcing stream forms: iterable/iterator of Forcing or a callable(k)->Forcing
+ForcingStream = Union[Iterable[Forcing], Iterator[Forcing], Callable[[int], Forcing]]
+
+
+def _as_iter(forcing_stream: ForcingStream | None) -> Iterator[Forcing]:
+    """Normalize a forcing stream into an iterator. If None, yield {} forever."""
+    if forcing_stream is None:
+        def gen() -> Iterator[Forcing]:
+            while True:
+                yield {}
+        return gen()
+
+    if callable(forcing_stream):
+        k = 0
+
+        def gen() -> Iterator[Forcing]:
+            nonlocal k
+            while True:
+                yield forcing_stream(k)
+                k += 1
+
+        return gen()
+    if hasattr(forcing_stream, "__iter__"):
+        return iter(forcing_stream)  # type: ignore[arg-type]
+    raise TypeError("forcing_stream must be Iterable[Forcing] or Callable[[int], Forcing]")
+
+
+def _normalize_cfg(cfg: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    """Provide a minimal cfg when None is given."""
+    if cfg is None:
+        return {"state0": {}, "params": {}}
+    return cfg
+
+
+def _bind_step(step: StepCallable) -> Callable[[State, Forcing, Params, float, XP], Tuple[State, Diag]]:
+    """Create a stable calling adapter for a given step function.
+
+    The adapter:
+    - Resolves the step's accepted parameter names via inspection
+    - Calls with keyword arguments for robustness: dt/state/forcing/params/xp
+    - Passes only parameters that the function actually declares
+    """
+    sig = inspect.signature(step)
+    accepted = set(sig.parameters.keys())
+
+    def call(state: State, forcing: Forcing, params: Params, dt: float, xp: XP) -> Tuple[State, Diag]:
+        kwargs: dict[str, Any] = {}
+        # Pass only what is accepted by the step signature
+        if "dt" in accepted:
+            kwargs["dt"] = dt
+        if "state" in accepted:
+            kwargs["state"] = state
+        if "forcing" in accepted:
+            kwargs["forcing"] = forcing
+        if "params" in accepted:
+            kwargs["params"] = params
+        if "xp" in accepted:
+            kwargs["xp"] = xp
+
+        # If the function uses the "full" core order (state, forcing, params, dt, *, xp)
+        # this will still work because we pass by keywords.
+        out = step(**kwargs)  # type: ignore[misc]
+        if not isinstance(out, tuple) or len(out) != 2:
+            raise TypeError("Step function must return a tuple (state, diag)")
+        new_state, diag = out
+        if diag is None:
+            diag = {}
+        elif not isinstance(diag, dict):
+            # Normalize non-dict diags into a dict for hooks/reporting
+            diag = {"diag": diag}
+        return new_state, diag
+
+    return call
+
+
+def make_runner(
+    step: StepCallable,
+    *,
+    cfg: Mapping[str, Any] | None = None,
+    xp: XP,
+    hooks: Tuple[Hook, ...] = (),
+    dt: float | None = None,
+) -> Callable[[ForcingStream | None, int], Tuple[State, Mapping[str, Any]]]:
+    """Create a minimal runner bound to a step, config, backend, and hooks.
+
+    Usage (WSGI-like):
+        runner = make_runner(step, cfg=None, xp=numpy, hooks=(timer_hook(...),), dt=None)
+        final_state, report = runner(None, 10)
+
+    Args:
+        step: A StepCallable implementing the (flexible) step contract.
+        cfg: Optional config mapping; init_fn will produce (state0, params).
+             If None, a minimal cfg is used: {"state0": {}, "params": {}}.
+        xp: Backend array namespace (e.g., numpy, jax.numpy, torch-like).
+        hooks: Observational hooks invoked per step; must not mutate state/params.
+        dt: Optional explicit timestep; overrides cfg["params"]["time"]["dt"].
+
+    Returns:
+        A callable (forcing_stream, n_steps) -> (final_state, report)
+    """
+    cfg = _normalize_cfg(cfg)
+    state0, params = init_fn(cfg, xp=xp)
+
+    # Resolve dt with priority: explicit dt > params["time"]["dt"] > default 1.0
+    params_time = params.get("time", {}) if isinstance(params.get("time", {}), Mapping) else {}
+    dt_final = float(dt if dt is not None else params_time.get("dt", 1.0))  # type: ignore[arg-type]
+
+    # Bind step once (no per-iteration signature overhead)
+    call_step = _bind_step(step)
+
+    def run(forcing_stream: ForcingStream | None, n_steps: int) -> Tuple[State, Mapping[str, Any]]:
+        st: State = state0
+        report: dict[str, Any] = {"timings": {"per_step_sec": []}, "last_diag": None}
+        fiter = _as_iter(forcing_stream)
+
+        for k in range(n_steps):
+            forcing = next(fiter, {})
+            t0 = perf_counter()
+            st, diag = call_step(st, forcing, params, dt_final, xp)
+            t1 = perf_counter()
+
+            # Timing into diag + report
+            dur = t1 - t0
+            (diag.setdefault("timings", {}))["step_sec"] = dur
+            report["timings"]["per_step_sec"].append(dur)
+
+            # Invoke hooks (observational only). Support both minimal and richer signatures.
+            for hook in hooks:
+                try:
+                    hook(k, st, diag)  # type: ignore[misc]
+                except TypeError:
+                    hook(k, st, diag, params=params, xp=xp)  # type: ignore[misc]
+
+            report["last_diag"] = diag
+
+        return st, report
+
+    return run
+
+
+def run(
+    step: StepCallable,
+    *,
+    n_steps: int,
+    xp: XP,
+    cfg: Mapping[str, Any] | None = None,
+    forcing_stream: ForcingStream | None = None,
+    hooks: Tuple[Hook, ...] = (),
+    dt: float | None = None,
+) -> Tuple[State, Mapping[str, Any]]:
+    """One-shot helper: initialize and execute a run with the provided step.
+
+    Examples
+        # Minimal (Hello, GCMI)
+        final_state, report = run(step, n_steps=5, xp=np)
+
+        # With explicit dt and a simple forcing stream
+        final_state, report = run(step, n_steps=10, xp=np, dt=60.0, forcing_stream=lambda k: {})
+
+        # With a non-empty cfg (state0/params) and hooks
+        final_state, report = run(step, n_steps=20, xp=np, cfg={"state0": {...}, "params": {"time": {"dt": 300}}}, hooks=(timer_hook(...),))
+
+    Note
+        Core contracts remain strict; this Driver API is a convenience layer that:
+        - supplies defaults (cfg/forcing_stream/forcing/params),
+        - adapts flexible step signatures by parameter name,
+        - preserves compatibility with middleware/hooks/tests built on the Core.
+    """
+    return make_runner(step, cfg=cfg, xp=xp, hooks=hooks, dt=dt)(forcing_stream, n_steps)

--- a/gcmi/hooks/__init__.py
+++ b/gcmi/hooks/__init__.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from .budgets import energy_budget_hook, water_budget_hook
+from .timing import timer_hook
+
+__all__ = [
+    "energy_budget_hook",
+    "water_budget_hook",
+    "timer_hook",
+]

--- a/gcmi/hooks/budgets.py
+++ b/gcmi/hooks/budgets.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from typing import IO, Any, Callable, Iterable, Mapping, Optional, Sequence
+
+from gcmi.ops import grid as grid_ops
+
+Hook = Callable[[int, dict[str, Any], dict[str, Any]], None]
+
+
+def _sum_any(x: Any, *, xp: Any | None) -> float:
+    """
+    Backend-neutral summation with graceful fallback to Python sum()/float().
+    """
+    if xp is not None:
+        try:
+            s = xp.sum(x)  # type: ignore[attr-defined]
+            try:
+                return float(s)  # type: ignore[arg-type]
+            except Exception:
+                return s  # type: ignore[return-value]
+        except Exception:
+            pass
+    # Fallbacks
+    try:
+        if isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
+            return float(sum(x))  # type: ignore[arg-type]
+    except Exception:
+        pass
+    try:
+        return float(x)  # type: ignore[arg-type]
+    except Exception:
+        return 0.0
+
+
+def energy_budget_hook(
+    *,
+    terms: Sequence[str] = ("dry_static", "latent", "kinetic"),
+    # Mapping from energy term name to state keys to sum; placeholders for M1
+    term_vars: Mapping[str, Sequence[str]] = {
+        "dry_static": ("T",),
+        "latent": ("q",),
+        "kinetic": ("u", "v"),
+    },
+    sink: Optional[IO[str]] = None,
+    fmt: str = "csv",  # 'csv' or 'ndjson'
+) -> Hook:
+    """
+    Construct a hook that computes simple energy-like totals from state variables.
+
+    For M1 this is a placeholder that sums selected state arrays by term using a backend-neutral
+    total; real energy calculations can replace this mapping later.
+
+    The hook records results under diag['budgets']['energy'] and optionally writes to sink.
+    """
+
+    def hook(k: int, state: dict[str, Any], diag: dict[str, Any], *_, **kwargs) -> None:
+        xp = kwargs.get("xp", None)
+
+        energy: dict[str, float] = {}
+        for term in terms:
+            total_val = 0.0
+            for var in term_vars.get(term, ()):
+                if var in state:
+                    try:
+                        total_val += grid_ops.total(state[var], xp=xp)
+                    except Exception:
+                        total_val += _sum_any(state[var], xp=xp)
+            energy[term] = float(total_val)
+
+        budgets = diag.setdefault("budgets", {})
+        budgets.setdefault("energy", {})[k] = energy
+
+        if sink is None:
+            return
+
+        if fmt == "csv":
+            # One line per step with comma-separated term totals (order per 'terms')
+            row = [str(k)] + [str(energy.get(t, 0.0)) for t in terms]
+            sink.write(",".join(row) + "\n")
+            sink.flush()
+        elif fmt == "ndjson":
+            rec = {"k": k, "energy": energy}
+            sink.write(json.dumps(rec) + "\n")
+            sink.flush()
+        else:
+            raise ValueError(f"Unsupported fmt: {fmt}")
+
+    return hook
+
+
+def water_budget_hook(
+    *,
+    var: str = "q",
+    sink: Optional[IO[str]] = None,
+    fmt: str = "csv",
+) -> Hook:
+    """
+    Construct a hook that computes a simple water budget: total of 'var' (default 'q').
+
+    Records under diag['budgets']['water'] and optionally writes to sink.
+    """
+
+    def hook(k: int, state: dict[str, Any], diag: dict[str, Any], *_, **kwargs) -> None:
+        xp = kwargs.get("xp", None)
+        total_q = 0.0
+        if var in state:
+            try:
+                total_q = grid_ops.total(state[var], xp=xp)
+            except Exception:
+                total_q = _sum_any(state[var], xp=xp)
+
+        budgets = diag.setdefault("budgets", {})
+        budgets.setdefault("water", {})[k] = {var: float(total_q)}
+
+        if sink is None:
+            return
+
+        if fmt == "csv":
+            sink.write(f"{k},{float(total_q)}\n")
+            sink.flush()
+        elif fmt == "ndjson":
+            sink.write(json.dumps({"k": k, var: float(total_q)}) + "\n")
+            sink.flush()
+        else:
+            raise ValueError(f"Unsupported fmt: {fmt}")
+
+    return hook

--- a/gcmi/hooks/timing.py
+++ b/gcmi/hooks/timing.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from typing import IO, Any, Callable, Optional
+
+# Hook signature (observational only): accepts optional params/xp via kwargs
+Hook = Callable[[int, dict[str, Any], dict[str, Any]], None]
+
+
+def timer_hook(
+    *,
+    sink: Optional[IO[str]] = None,
+    fmt: str = "csv",
+    include_diag: bool = False,
+) -> Hook:
+    """
+    Create a timing hook that records per-step elapsed wall-clock time.
+
+    The run loop is expected to attach a per-step timing into diag["timings"]["step_sec"].
+    This hook reads that value and optionally writes it to a stream.
+
+    Args:
+        sink: Optional text file-like (opened in append mode) to write records.
+              If None, the hook only ensures a timings entry exists in diag.
+        fmt: 'csv' or 'ndjson' when sink is provided.
+        include_diag: If True and fmt == 'ndjson', include the full diag in the record.
+
+    Returns:
+        A hook callable with signature hook(k, state, diag, ..., params=?, xp=?)
+    """
+
+    def hook(k: int, state: dict[str, Any], diag: dict[str, Any], *_, **__) -> None:
+        timings = diag.setdefault("timings", {})
+        step_sec = timings.get("step_sec", None)
+
+        # If there is no timing attached yet, do nothing beyond ensuring the key exists
+        if step_sec is None:
+            return
+
+        if sink is None:
+            return
+
+        if fmt == "csv":
+            # Write header once if file is empty? We avoid file state checks for simplicity.
+            sink.write(f"{k},{step_sec}\n")
+            sink.flush()
+        elif fmt == "ndjson":
+            rec: dict[str, Any] = {"k": k, "step_sec": step_sec}
+            if include_diag:
+                rec["diag"] = diag
+            sink.write(json.dumps(rec) + "\n")
+            sink.flush()
+        else:
+            raise ValueError(f"Unsupported fmt: {fmt}")
+
+    return hook

--- a/gcmi/middleware/__init__.py
+++ b/gcmi/middleware/__init__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from .core import (with_cfl_guard, with_conservation_projection,
+                   with_energy_fix, with_flux_limiter, with_hyperdiff,
+                   with_positivity)
+from .requirements import with_requirements_check
+
+__all__ = [
+    "with_requirements_check",
+    "with_cfl_guard",
+    "with_hyperdiff",
+    "with_flux_limiter",
+    "with_positivity",
+    "with_energy_fix",
+    "with_conservation_projection",
+]

--- a/gcmi/middleware/core.py
+++ b/gcmi/middleware/core.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import math
+from typing import (Any, Callable, Dict, Mapping, Sequence, Tuple, TypedDict,
+                    cast)
+
+# Loose typing aliases to avoid import cycles with gcmi.core.api
+State = Dict[str, Any]
+Forcing = Dict[str, Any]
+Params = Mapping[str, Any]
+Diag = Dict[str, Any]
+StepFn = Callable[[State, Forcing, Params, float], Tuple[State, Diag]]
+
+
+class XPProto(TypedDict, total=False):
+    # Minimal structural typing hint for xp-like namespaces if needed by linters
+    pass
+
+
+def _append_mw_meta(diag: Diag, name: str, **meta: Any) -> None:
+    (diag.setdefault("gcmi_mw", [])).append({"name": name, **meta})
+
+
+def with_cfl_guard(
+    step: StepFn,
+    *,
+    cfl_max: float = 0.8,
+    wave_speed_cb: Callable[[State, Params, Any], float],
+) -> StepFn:
+    """
+    Stability middleware: enforce dt against a CFL criterion via optional substepping.
+
+    Behavior:
+    - Compute vmax = wave_speed_cb(state, params, xp)
+    - dx := params['grid']['dx_min'] if present else 1.0
+    - cfl := vmax * dt / dx
+    - If cfl <= cfl_max: single inner step
+    - Else: perform n_sub = ceil(cfl / cfl_max) sub-steps with dt_sub = dt / n_sub
+
+    Notes:
+    - This is a generic controller; it does not alter physics except time slicing.
+    - Metadata is recorded under diag["gcmi_mw"].
+    """
+
+    def wrapped(state: State, forcing: Forcing, params: Params, dt: float, *, xp):
+        vmax = float(wave_speed_cb(state, params, xp))
+        dx = 1.0
+        try:
+            grid = cast(Mapping[str, Any], params.get("grid", {}))
+            if "dx_min" in grid:
+                dx = float(grid["dx_min"])
+        except Exception:
+            dx = 1.0
+
+        cfl = 0.0 if dx == 0 else vmax * dt / dx
+        if cfl <= cfl_max or dx == 0.0 or vmax == 0.0 or dt == 0.0:
+            st, dg = step(state, forcing, params, dt, xp=xp)
+            _append_mw_meta(
+                dg, "cfl_guard", cfl=cfl, n_substeps=1, vmax=vmax, dx=dx, dt=dt
+            )
+            return st, dg
+
+        n_sub = max(1, int(math.ceil(cfl / cfl_max)))
+        dt_sub = dt / n_sub if n_sub > 0 else dt
+        st = state
+        last_diag: Diag = {}
+        for _ in range(n_sub):
+            st, last_diag = step(st, forcing, params, dt_sub, xp=xp)
+        _append_mw_meta(
+            last_diag,
+            "cfl_guard",
+            cfl=cfl,
+            n_substeps=n_sub,
+            vmax=vmax,
+            dx=dx,
+            dt=dt,
+            dt_sub=dt_sub,
+        )
+        return st, last_diag
+
+    setattr(wrapped, "__wrapped__", step)
+    return wrapped  # type: ignore[return-value]
+
+
+def with_hyperdiff(
+    step: StepFn,
+    *,
+    coeff: float = 0.0,
+    order: int = 4,
+    vars: Sequence[str] = ("T", "u", "v"),
+) -> StepFn:
+    """
+    Add hyperdiffusion (placeholder via ops.grid.laplacian). For M1, laplacian may be a no-op.
+
+    Args:
+        coeff: diffusion coefficient (applied as: var <- var - coeff * Laplacian(var))
+        order: nominal order (recorded in metadata only for M1)
+        vars: variables to diffuse if present in state
+    """
+    from gcmi.ops import grid as grid_ops  # local import to avoid cycles
+
+    def wrapped(state: State, forcing: Forcing, params: Params, dt: float, *, xp):
+        st, dg = step(state, forcing, params, dt, xp=xp)
+        if coeff != 0.0:
+            for v in vars:
+                if v in st:
+                    try:
+                        lap_v = grid_ops.laplacian(st[v], xp=xp)
+                        st[v] = st[v] - coeff * lap_v  # type: ignore[operator]
+                    except Exception:
+                        # On type incompatibility, skip modification but continue
+                        pass
+        _append_mw_meta(dg, "hyperdiff", coeff=coeff, order=order, vars=tuple(vars))
+        return st, dg
+
+    setattr(wrapped, "__wrapped__", step)
+    return wrapped  # type: ignore[return-value]
+
+
+def with_flux_limiter(
+    step: StepFn,
+    *,
+    scheme: str = "mc",
+    vars: Sequence[str] = ("q", "T"),
+) -> StepFn:
+    """
+    Flux limiter (placeholder). For M1, records metadata; no state change.
+    """
+
+    def wrapped(state: State, forcing: Forcing, params: Params, dt: float, *, xp):
+        st, dg = step(state, forcing, params, dt, xp=xp)
+        _append_mw_meta(dg, "flux_limiter", scheme=scheme, vars=tuple(vars))
+        return st, dg
+
+    setattr(wrapped, "__wrapped__", step)
+    return wrapped  # type: ignore[return-value]
+
+
+def with_positivity(
+    step: StepFn,
+    *,
+    vars: Sequence[str] = ("q",),
+    lower: float = 0.0,
+    conserve: str | None = None,  # placeholder: not enforced in M1
+) -> StepFn:
+    """
+    Enforce non-negativity via clamping for selected variables.
+    """
+    from gcmi.ops import grid as grid_ops  # local import
+
+    def wrapped(state: State, forcing: Forcing, params: Params, dt: float, *, xp):
+        st, dg = step(state, forcing, params, dt, xp=xp)
+        for v in vars:
+            if v in st:
+                try:
+                    st[v] = grid_ops.clamp_min(st[v], lower, xp=xp)
+                except Exception:
+                    # If clamp fails, skip
+                    pass
+        _append_mw_meta(
+            dg, "positivity", vars=tuple(vars), lower=lower, conserve=conserve
+        )
+        return st, dg
+
+    setattr(wrapped, "__wrapped__", step)
+    return wrapped  # type: ignore[return-value]
+
+
+def with_energy_fix(
+    step: StepFn,
+    *,
+    budget: Sequence[str] = ("dry_static", "latent", "kinetic"),
+) -> StepFn:
+    """
+    Global energy budget correction (placeholder). For M1, records metadata only.
+    """
+
+    def wrapped(state: State, forcing: Forcing, params: Params, dt: float, *, xp):
+        st, dg = step(state, forcing, params, dt, xp=xp)
+        _append_mw_meta(dg, "energy_fix", budget=tuple(budget))
+        return st, dg
+
+    setattr(wrapped, "__wrapped__", step)
+    return wrapped  # type: ignore[return-value]
+
+
+def with_conservation_projection(
+    step: StepFn,
+    *,
+    conserve: Sequence[str] = ("total_mass", "moist_energy"),
+) -> StepFn:
+    """
+    Projection onto conserved totals (placeholder). For M1, records metadata only.
+    """
+
+    def wrapped(state: State, forcing: Forcing, params: Params, dt: float, *, xp):
+        st, dg = step(state, forcing, params, dt, xp=xp)
+        _append_mw_meta(dg, "conservation_projection", conserve=tuple(conserve))
+        return st, dg
+
+    setattr(wrapped, "__wrapped__", step)
+    return wrapped  # type: ignore[return-value]

--- a/gcmi/middleware/requirements.py
+++ b/gcmi/middleware/requirements.py
@@ -25,12 +25,8 @@ from __future__ import annotations
 
 from typing import Any, Callable, Dict, Mapping, Sequence, Tuple
 
-from gcmi.utils.requirements import (
-    Requirement,
-    RequirementError,
-    get_requirements,
-    validate_requirements,
-)
+from gcmi.utils.requirements import (Requirement, RequirementError,
+                                     get_requirements, validate_requirements)
 
 # Loose typing to avoid import-cycle with core types
 StepFn = Callable[

--- a/gcmi/ops/__init__.py
+++ b/gcmi/ops/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from . import grid
+
+__all__ = ["grid"]

--- a/gcmi/ops/grid.py
+++ b/gcmi/ops/grid.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol
+
+
+class XP(Protocol):
+    def maximum(self, x: Any, y: Any): ...
+    def sum(self, x: Any): ...
+    def zeros_like(self, x: Any): ...
+    def asarray(self, x: Any): ...
+
+
+def identity(x: Any, *, xp: XP) -> Any:
+    """
+    Minimal placeholder operator that returns input unchanged.
+    Useful as a no-op default when wiring ops.
+    """
+    return x
+
+
+def laplacian(
+    field: Any, *, xp: XP, dx: float | None = None, dy: float | None = None
+) -> Any:
+    """
+    Placeholder Laplacian operator.
+
+    For M1, we provide a safe no-op that returns zeros_like(field) if available,
+    otherwise returns the input unchanged. This establishes the ops facade and
+    call sites; numerical implementation can be filled in subsequent milestones.
+    """
+    try:
+        return xp.zeros_like(field)
+    except Exception:
+        # Fallback to identity if zeros_like is not available
+        return field
+
+
+def clamp_min(field: Any, lower: float, *, xp: XP) -> Any:
+    """
+    Clamp to a lower bound in a backend-neutral way.
+    Falls back to Python max for scalar values if xp.maximum is unavailable.
+    """
+    try:
+        return xp.maximum(field, lower)  # type: ignore[arg-type]
+    except Exception:
+        try:
+            return max(field, lower)  # type: ignore[type-var]
+        except Exception:
+            return field
+
+
+def total(field: Any, *, xp: XP) -> float:
+    """
+    Compute a total (sum) in a backend-neutral way.
+    Returns float where possible; otherwise attempts to cast.
+    """
+    try:
+        s = xp.sum(field)
+        try:
+            return float(s)  # type: ignore[arg-type]
+        except Exception:
+            return s  # type: ignore[return-value]
+    except Exception:
+        # Fallback: if scalar-like
+        try:
+            return float(field)  # type: ignore[arg-type]
+        except Exception:
+            return 0.0
+
+
+def dx_min_from_params(params: Mapping[str, Any]) -> float | None:
+    """
+    Helper to obtain grid.dx_min from params if present.
+    """
+    try:
+        grid = params.get("grid", {})  # type: ignore[assignment]
+        return float(grid.get("dx_min"))  # type: ignore[arg-type]
+    except Exception:
+        return None

--- a/gcmi/utils/requirements.py
+++ b/gcmi/utils/requirements.py
@@ -21,7 +21,8 @@ Notes:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, List, Literal, Mapping, Optional, Sequence, Tuple
+from typing import (Any, Callable, List, Literal, Mapping, Optional, Sequence,
+                    Tuple)
 
 Where = Literal["state", "params", "forcing"]
 Severity = Literal["error", "warn"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,9 @@ name = "py-gcmi"
 version = "0.1.0"
 description = "The Python general circulation model interface"
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+    "numpy>=2.2.6",
+]
 
 [project.optional-dependencies]
 dev = [
@@ -20,3 +22,8 @@ dev = [
 [tool.setuptools.packages.find]
 include = ["gcmi*", "pygcmi*"]
 exclude = ["ideas*", "projects*", "docs*", "tests*"]
+
+[tool.pytest.ini_options]
+# Restrict test discovery to our first-party tests only (exclude vendor scripts)
+testpaths = ["tests"]
+addopts = "-q"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure project root is on sys.path so 'import gcmi' works when running pytest
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)

--- a/tests/core/test_baselines.py
+++ b/tests/core/test_baselines.py
@@ -1,0 +1,143 @@
+import copy
+from typing import Any, Dict
+
+import gcmi.core.api as core_api
+from gcmi.hooks import energy_budget_hook, water_budget_hook
+from gcmi.middleware import with_cfl_guard
+
+
+class XPStub:
+    # Minimal 'xp' stub used by tests; compatible with our hooks/ops placeholders
+    def sum(self, x):
+        try:
+            return sum(x)  # works for lists
+        except TypeError:
+            return x  # scalar
+
+    def zeros_like(self, x):
+        try:
+            return [0 for _ in x]
+        except TypeError:
+            return 0
+
+
+def _forcing_fn(k: int) -> Dict[str, Any]:
+    # No forcing for baseline tests
+    return {}
+
+
+def _copy_state(state: Dict[str, Any]) -> Dict[str, Any]:
+    # Deep copy lists; values are kept simple in tests
+    return copy.deepcopy(state)
+
+
+def test_conservation_identity_baseline():
+    """
+    Dry/no forcing: totals remain constant with identity core step.
+    """
+    xp = XPStub()
+    state0 = {
+        "T": [1.0, 2.0, 3.0],
+        "q": [0.1, 0.2, 0.3],
+        "u": [1.0, -1.0, 0.5],
+        "v": [0.5, 0.0, -0.5],
+        "misc": {"seed": 123},
+    }
+    params = {"time": {"dt": 1.0}, "grid": {"dx_min": 1.0}}
+
+    # Totals at start
+    t0 = float(xp.sum(state0["T"]))
+    q0 = float(xp.sum(state0["q"]))
+    u0 = float(xp.sum(state0["u"]))
+    v0 = float(xp.sum(state0["v"]))
+
+    # Use identity core step (module-level default) with no middleware
+    init_state, init_params = state0, params
+
+    # Run
+    final_state, report = core_api.run_fn(
+        init=init_state,
+        params=init_params,
+        forcing_stream=_forcing_fn,
+        xp=xp,
+        n_steps=5,
+        hooks=(
+            energy_budget_hook(),  # just to exercise hooks path
+            water_budget_hook(),
+        ),
+    )
+
+    # Totals at end should match
+    assert float(xp.sum(final_state["T"])) == t0
+    assert float(xp.sum(final_state["q"])) == q0
+    assert float(xp.sum(final_state["u"])) == u0
+    assert float(xp.sum(final_state["v"])) == v0
+
+
+def test_cfl_guard_substepping_and_metadata():
+    """
+    CFL guard: when vmax*dt/dx exceeds threshold, uses substepping and records metadata.
+    """
+    xp = XPStub()
+    state0 = {"T": [1.0, 2.0], "misc": {}}
+    params = {"time": {"dt": 1.0}, "grid": {"dx_min": 1.0}}
+
+    # Define a trivial step that just echoes diag; allows metadata injection to be observed
+    def base_step(state, forcing, params, dt, *, xp=None):
+        return state, {"gcmi_mw": []}
+
+    # Wave speed large enough to force substeps for cfl_max=0.5
+    def wave_speed_cb(state, params, xp):
+        return 10.0
+
+    wrapped = with_cfl_guard(base_step, cfl_max=0.5, wave_speed_cb=wave_speed_cb)
+
+    # Monkey-patch the module-level step_fn for this test
+    old = core_api.step_fn
+    core_api.step_fn = wrapped  # type: ignore[assignment]
+    try:
+        final_state, report = core_api.run_fn(
+            init=state0,
+            params=params,
+            forcing_stream=_forcing_fn,
+            xp=xp,
+            n_steps=1,
+            hooks=(),
+        )
+    finally:
+        core_api.step_fn = old  # restore
+
+    # The last diag is in report["last_diag"]
+    diag = report["last_diag"] or {}
+    mw = diag.get("gcmi_mw", [])
+    assert mw, "Expected middleware metadata entries"
+    cfl_entries = [m for m in mw if m.get("name") == "cfl_guard"]
+    assert cfl_entries, "Expected cfl_guard metadata entry"
+    assert cfl_entries[-1]["n_substeps"] >= 2
+
+
+def test_reproducibility_identity_fixed_rng():
+    """
+    With identity step and fixed initial state, repeated runs produce identical final states.
+    """
+    xp = XPStub()
+    state0 = {"q": [0.1, 0.2, 0.3], "misc": {"seed": 42}}
+    params = {"time": {"dt": 1.0}}
+
+    def run_once():
+        st, rep = core_api.run_fn(
+            init=_copy_state(state0),
+            params=params,
+            forcing_stream=_forcing_fn,
+            xp=xp,
+            n_steps=3,
+            hooks=(),
+        )
+        return st
+
+    st1 = run_once()
+    st2 = run_once()
+
+    assert (
+        st1 == st2
+    ), "Final states should be identical across runs for identity dynamics"

--- a/tests/examples/test_minimal.py
+++ b/tests/examples/test_minimal.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+
+from gcmi.drivers import run
+
+
+def test_minimal_hello_world_runs() -> None:
+    # Minimal signature: step(dt, state, *, xp)
+    def step(dt: float, state: Dict[str, Any], *, xp: Any) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        # Ensure driver passes through the backend namespace
+        assert xp is np
+        # Identity step: return state and empty diag
+        return state, {}
+
+    final_state, report = run(step, n_steps=3, xp=np)
+
+    assert isinstance(final_state, dict)
+    assert "timings" in report and "per_step_sec" in report["timings"]
+    timings = report["timings"]["per_step_sec"]
+    assert isinstance(timings, list)
+    assert len(timings) == 3
+    assert "last_diag" in report and "timings" in report["last_diag"]
+    assert "step_sec" in report["last_diag"]["timings"]
+
+
+def test_minimal_with_cfg_state_pass_through() -> None:
+    cfg = {"state0": {"T": np.array(300.0)}, "params": {"time": {"dt": 1.0}}}
+
+    def step(dt: float, state: Dict[str, Any], *, xp: Any) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        # Identity step
+        return state, {}
+
+    final_state, report = run(step, n_steps=2, xp=np, cfg=cfg)
+
+    assert "T" in final_state
+    # Identity step should preserve initial field
+    assert np.allclose(final_state["T"], 300.0)
+    assert len(report["timings"]["per_step_sec"]) == 2
+
+
+def test_back_compat_signature_full_core_order() -> None:
+    # Back-compatible signature: step(state, forcing, params, dt, *, xp)
+    def step(
+        state: Dict[str, Any],
+        forcing: Dict[str, Any],
+        params: Dict[str, Any],
+        dt: float,
+        *,
+        xp: Any,
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        # Driver should supply empty forcing/params when omitted by caller
+        assert isinstance(forcing, dict)
+        assert isinstance(params, dict)
+        assert xp is np
+        return state, {}
+
+    final_state, report = run(step, n_steps=1, xp=np)
+
+    assert isinstance(final_state, dict)
+    assert len(report["timings"]["per_step_sec"]) == 1
+
+
+def test_forcing_stream_and_dt_override() -> None:
+    calls: List[int] = []
+
+    def step(dt: float, state: Dict[str, Any], *, xp: Any) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        # Check dt override propagates
+        assert dt == 2.5
+        calls.append(1)
+        return state, {}
+
+    final_state, report = run(step, n_steps=4, xp=np, dt=2.5, forcing_stream=lambda k: {})
+    assert isinstance(final_state, dict)
+    assert len(calls) == 4
+    assert len(report["timings"]["per_step_sec"]) == 4
+
+
+def test_diag_normalization_when_none() -> None:
+    def step(dt: float, state: Dict[str, Any], *, xp: Any) -> Tuple[Dict[str, Any], None]:
+        # Return None diag; driver should normalize and attach timings
+        return state, None  # type: ignore[return-value]
+
+    _, report = run(step, n_steps=1, xp=np)
+    assert "last_diag" in report and "timings" in report["last_diag"]
+    assert "step_sec" in report["last_diag"]["timings"]

--- a/tests/utils/test_requirements.py
+++ b/tests/utils/test_requirements.py
@@ -1,10 +1,6 @@
-from gcmi.utils.requirements import (
-    Requirement,
-    RequirementError,
-    get_requirements,
-    requires,
-    validate_requirements,
-)
+from gcmi.utils.requirements import (Requirement, RequirementError,
+                                     get_requirements, requires,
+                                     validate_requirements)
 
 
 def test_validate_requirements_ok_and_types_and_predicate():


### PR DESCRIPTION
Summary:
- Introduce a WSGI-inspired minimal driver API (gcmi.drivers.run/make_runner) with flexible step signatures (supports step(dt, state, *, xp) and the full core signature).
- Provide sensible defaults (cfg=None, forcing_stream=None, dt resolution) to enable a 20-line Hello, GCMI.
- Enrich core API docstrings in gcmi/core/api.py to clearly explain State/Forcing/Params/Diag semantics and the assembly/run flow.
- Add tests to guarantee the minimal example remains runnable and stable.

Checks:
- isort applied
- ruff check . --fix applied
- pytest green

Notes:
- Core strict contracts remain unchanged; the convenience layer lives under gcmi.drivers, preserving middleware/hooks/test compatibility.